### PR TITLE
Fixed null reference exception when syncing liked lists

### DIFF
--- a/TraktAPI/DataStructures/TraktLike.cs
+++ b/TraktAPI/DataStructures/TraktLike.cs
@@ -3,51 +3,51 @@ using System.Runtime.Serialization;
 
 namespace TraktAPI.DataStructures
 {
-    [DataContract]
-    public class TraktLike : IEquatable<TraktLike>
+  [DataContract]
+  public class TraktLike : IEquatable<TraktLike>
+  {
+    [DataMember( Name = "liked_at" )]
+    public string LikedAt { get; set; }
+
+    [DataMember( Name = "type" )]
+    public string Type { get; set; }
+
+    [DataMember( Name = "list" )]
+    public TraktListDetail List { get; set; }
+
+    [DataMember( Name = "comment" )]
+    public TraktComment Comment { get; set; }
+
+    #region IEquatable
+    public bool Equals( TraktLike other )
     {
-        [DataMember(Name = "liked_at")]
-        public string LikedAt { get; set; }
+      if ( other == null || ( other.Comment == null && other.Type == "comment" ) || ( other.List == null && other.Type == "list" ) )
+        return false;
 
-        [DataMember(Name = "type")]
-        public string Type { get; set; }
+      if ( this.Type == "list" )
+      {
+        if ( this.List.Id == null || other.List.Id == null )
+          return false;
 
-        [DataMember(Name = "list")]
-        public TraktListDetail List { get; set; }
-
-        [DataMember(Name = "comment")]
-        public TraktComment Comment { get; set; }
-
-        #region IEquatable
-        public bool Equals(TraktLike other)
-        {
-            if (other == null || (other.Comment == null && other.Type == "comment") || (other.List == null && other.Type == "list"))
-                return false;
-
-            if (this.Type == "list")
-            {
-                if (this.List.Ids == null || other.List.Ids == null)
-                    return false;
-
-                return (this.Type == other.Type && this.List.Ids.Trakt == other.List.Ids.Trakt);
-            }
-            else
-            {
-                return (this.Type == other.Type && this.Comment.Id == other.Comment.Id);
-            }
-        }
-
-        public override int GetHashCode()
-        {
-            if (this.Type == "list")
-            {
-                return (this.List.Ids.Trakt.ToString() + "_" + this.Type).GetHashCode();
-            }
-            else
-            {
-                return (this.Comment.Id.ToString() + "_" + this.Type).GetHashCode();
-            }
-        }
-        #endregion
+        return ( this.Type == other.Type && this.List.Id == other.List.Id );
+      }
+      else
+      {
+        return ( this.Type == other.Type && this.Comment.Id == other.Comment.Id );
+      }
     }
+
+    public override int GetHashCode()
+    {
+      if ( this.Type == "list" )
+      {
+        return ( this.List.Id.ToString() + "_" + this.Type ).GetHashCode();
+      }
+      else
+      {
+        return ( this.Comment.Id.ToString() + "_" + this.Type ).GetHashCode();
+      }
+    }
+    #endregion
+  }
 }

--- a/TraktAPI/DataStructures/TraktListDetail.cs
+++ b/TraktAPI/DataStructures/TraktListDetail.cs
@@ -2,28 +2,31 @@
 
 namespace TraktAPI.DataStructures
 {
-    [DataContract]
-    public class TraktListDetail : TraktList
-    {
-        [DataMember(Name = "updated_at")]
-        public string UpdatedAt { get; set; }
+  [DataContract]
+  public class TraktListDetail : TraktList
+  {
+    [DataMember( Name = "updated_at" )]
+    public string UpdatedAt { get; set; }
 
-        [DataMember(Name = "created_at")]
-        public string CreatedAt { get; set; }
+    [DataMember( Name = "created_at" )]
+    public string CreatedAt { get; set; }
 
-        [DataMember(Name = "item_count")]
-        public int ItemCount { get; set; }
+    [DataMember( Name = "item_count" )]
+    public int ItemCount { get; set; }
 
-        [DataMember(Name = "comment_count")]
-        public int Comments { get; set; }
+    [DataMember( Name = "comment_count" )]
+    public int Comments { get; set; }
 
-        [DataMember(Name = "likes")]
-        public int Likes { get; set; }
+    [DataMember( Name = "likes" )]
+    public int Likes { get; set; }
 
-        [DataMember(Name = "ids")]
-        public TraktId Ids { get; set; }
+    [DataMember( Name = "id" )]
+    public int? Id { get; set; }
 
-        [DataMember(Name = "user")]
-        public TraktUser User { get; set; }
-    }
+    [DataMember( Name = "ids" )]
+    public TraktId Ids { get; set; }
+
+    [DataMember( Name = "user" )]
+    public TraktUser User { get; set; }
+  }
 }

--- a/TraktPlugin/Cache/TraktCache.cs
+++ b/TraktPlugin/Cache/TraktCache.cs
@@ -1621,7 +1621,7 @@ namespace TraktPlugin
                 if (LikedLists != null && pagedItems.IsAny())
                 {
                     // if the list id exists then we already have all liked lists
-                    listExists = LikedLists.Any(l => l.List.Ids.Trakt == pagedItems.Last().List.Ids.Trakt);
+                    listExists = LikedLists.Any(l => l.List.Id == pagedItems.Last().List.Id);
 
                     // add the latest page to our previous cached comments
                     pagedItems = pagedItems.Union(LikedLists);
@@ -1636,7 +1636,7 @@ namespace TraktPlugin
                         if (nextPage == null || !nextPage.Likes.IsAny()) break;
 
                         // if the list id exists then we already have all liked lists
-                        if (pagedItems.Any(c => c.List.Ids.Trakt == nextPage.Likes.Last().List.Ids.Trakt))
+                        if (pagedItems.Any(c => c.List.Id == nextPage.Likes.Last().List.Id))
                             listExists = true;
 
                         // add the latest page to our previous requested liked lists

--- a/TraktPlugin/TraktSettings.cs
+++ b/TraktPlugin/TraktSettings.cs
@@ -19,10 +19,10 @@ namespace TraktPlugin
 {
     public class TraktSettings
     {
-        private static Object lockObject = new object();
+        private static readonly Object lockObject = new object();
 
         #region Settings
-        static int SettingsVersion = 12;
+        static readonly int SettingsVersion = 13;
 
         public static int MovingPictures { get; set; }
         public static int TVSeries { get; set; }
@@ -1393,6 +1393,26 @@ namespace TraktPlugin
                             xmlreader.RemoveEntry(cTrakt, "DefaultCalendarStartDate");
                             xmlreader.RemoveEntry(cTrakt, "DefaultCalendarView");
                             break;
+                        case 12:
+                          // remove cached liked lists for each user (API model update)
+                          try
+                          {
+                            var di = new DirectoryInfo( Path.Combine( Config.GetFolder( Config.Dir.Config ), @"Trakt" ) );
+
+                            foreach ( FileInfo file in di.GetFiles( "Liked.json", SearchOption.AllDirectories ) )
+                            {
+                              file.Delete();
+                            }
+
+                            // clear the cached activity times to force a full sync of all activities including likes
+                            xmlreader.RemoveEntry( cTrakt, cLastSyncActivities );
+                          }
+                          catch ( Exception e )
+                          {
+                            TraktLogger.Error( "Failed to remove previously cached liked lists, Reason = '{0}'", e.Message );
+                          }
+                          currentSettingsVersion++;
+                          break;
                     }
                 }
             }


### PR DESCRIPTION
Seems like the model has changed on the API since this was implemented. It only affects the "min" API i.e. on min they add a id property but on the full they have a ids e.g.
```
{
    "liked_at": "2019-12-30T01:30:48.000Z",
    "type": "list",
    "list": {
      "name": "Trakt: Popular Movies",
      "description": "The Trakt top 250 movies, based on popularity. List updated daily.",
      "privacy": "public",
      "share_link": "https://trakt.tv/lists/4834049",
      "type": "personal",
      "display_numbers": true,
      "allow_comments": true,
      "sort_by": "rank",
      "sort_how": "asc",
      "created_at": "2018-05-13T16:33:23.000Z",
      "updated_at": "2026-03-31T14:02:40.000Z",
      "item_count": 251,
      "comment_count": 0,
      "likes": 402,
      "ids": {
        "trakt": 4834049,
        "slug": "trakt-popular-movies"
      },
      "user": {
        "username": "justin",
        "private": false,
        "deleted": false,
        "name": "Justin",
        "vip": true,
        "vip_ep": true,
        "director": true,
        "ids": {
          "slug": "justin"
        },
        "joined_at": "2010-09-25T17:49:25.000Z",
        "location": "United States",
        "about": "Do the truffle shuffle!!",
        "gender": "male",
        "age": 44,
        "images": {
          "avatar": {
            "full": "https://walter-r2.trakt.tv/images/admins/000/000/001/avatars/large/2e6df69058.jpg"
          }
        }
      }
    }
  }
```
vs
```
  {
    "liked_at": "2015-09-18T01:23:14.000Z",
    "type": "list",
    "list": {
      "id": 1402475
    }
  },
```