### PR TITLE
Updated movie, show and episode properties and API updates

### DIFF
--- a/MPEI/TraktInstaller.xmp2
+++ b/MPEI/TraktInstaller.xmp2
@@ -1562,12 +1562,14 @@ Click Next to continue or Cancel to exit Setup.
 
 
 Trakt will also synchronize your watched flags across multiple installations.</ExtensionDescription>
-    <VersionDescription>* Support for pagination on Watched and Ratings sync
+    <VersionDescription>* Updated skin properties
+* Set pagination max items to 250 due to future API restrictions.
+* Protect against bad data from API request on movie collection endpoint.
 
 </VersionDescription>
     <DevelopmentStatus>Stable</DevelopmentStatus>
     <OnlineLocation>https://github.com/Mediaportal-Plugin-Team/Trakt-for-Mediaportal/releases/download/v[Version]/TraktPlugin-v[Version].mpe1</OnlineLocation>
-    <ReleaseDate>2026-04-26T13:13:13</ReleaseDate>
+    <ReleaseDate>2026-05-03T13:13:13</ReleaseDate>
     <Tags>trakt,tv shows,movies,mp-tvseries,movingpictures,my videos,my films</Tags>
     <PlatformCompatibility>AnyCPU</PlatformCompatibility>
     <Location>.\Release\TraktPlugin-v[Version].mpe1</Location>

--- a/TraktAPI/DataStructures/TraktEpisodeId.cs
+++ b/TraktAPI/DataStructures/TraktEpisodeId.cs
@@ -2,19 +2,19 @@
 
 namespace TraktAPI.DataStructures
 {
-    [DataContract]
-    public class TraktEpisodeId : TraktId
-    {
-        [DataMember(Name = "imdb")]
-        public string Imdb { get; set; }
+  [DataContract]
+  public class TraktEpisodeId : TraktId
+  {
+    [DataMember( Name = "imdb" )]
+    public string Imdb { get; set; }
 
-        [DataMember(Name = "tmdb")]
-        public int? Tmdb { get; set; }
+    [DataMember( Name = "tmdb" )]
+    public int? Tmdb { get; set; }
 
-        [DataMember(Name = "tvdb")]
-        public int? Tvdb { get; set; }
+    [DataMember( Name = "tvdb" )]
+    public int? Tvdb { get; set; }
 
-        [DataMember(Name = "tvrage")]
-        public int? TvRage { get; set; }
-    }
+    [DataMember( Name = "plex" )]
+    public TraktPlexId Plex { get; set; }
+  }
 }

--- a/TraktAPI/DataStructures/TraktEpisodeSummary.cs
+++ b/TraktAPI/DataStructures/TraktEpisodeSummary.cs
@@ -3,31 +3,49 @@ using System.Runtime.Serialization;
 
 namespace TraktAPI.DataStructures
 {
-    [DataContract]
-    public class TraktEpisodeSummary : TraktEpisode
-    {
-        [DataMember(Name = "number_abs")]
-        public int? AbsoluteNumber { get; set; }
+  [DataContract]
+  public class TraktEpisodeSummary : TraktEpisode
+  {
+    [DataMember( Name = "number_abs" )]
+    public int? AbsoluteNumber { get; set; }
 
-        [DataMember(Name = "first_aired")]
-        public string FirstAired { get; set; }
+    [DataMember( Name = "first_aired" )]
+    public string FirstAired { get; set; }
 
-        [DataMember(Name = "updated_at")]
-        public string UpdatedAt { get; set; }
+    [DataMember( Name = "updated_at" )]
+    public string UpdatedAt { get; set; }
 
-        [DataMember(Name = "overview")]
-        public string Overview { get; set; }
+    [DataMember( Name = "overview" )]
+    public string Overview { get; set; }
 
-        [DataMember(Name = "rating")]
-        public double? Rating { get; set; }
+    [DataMember( Name = "rating" )]
+    public double? Rating { get; set; }
 
-        [DataMember(Name = "votes")]
-        public int Votes { get; set; }
+    [DataMember( Name = "votes" )]
+    public int Votes { get; set; }
 
-        [DataMember(Name = "comment_count")]
-        public int CommentCount { get; set; }
+    [DataMember( Name = "comment_count" )]
+    public int CommentCount { get; set; }
 
-        [DataMember(Name = "available_translations")]
-        public List<string> AvailableTranslations { get; set; }
-    }
+    [DataMember( Name = "available_translations" )]
+    public List<string> AvailableTranslations { get; set; }
+
+    [DataMember( Name = "original_title" )]
+    public string OriginalTitle { get; set; }
+
+    [DataMember( Name = "released" )]
+    public string Released { get; set; }
+
+    [DataMember( Name = "effective_release_date" )]
+    public string EffectiveReleaseDate { get; set; }
+
+    [DataMember( Name = "episode_type" )]
+    public string EpisodeType { get; set; }
+
+    [DataMember( Name = "after_credits" )]
+    public bool AfterCredits { get; set; }
+
+    [DataMember( Name = "during_credits" )]
+    public bool DuringCredits { get; set; }
+  }
 }

--- a/TraktAPI/DataStructures/TraktEpisodeWatchlist.cs
+++ b/TraktAPI/DataStructures/TraktEpisodeWatchlist.cs
@@ -13,5 +13,8 @@ namespace TraktAPI.DataStructures
   {
     [DataMember( Name = "listed_at" )]
     public string ListedAt { get; set; }
+
+    [DataMember( Name = "notes" )]
+    public string Notes { get; set; }
   }
 }

--- a/TraktAPI/DataStructures/TraktListItem.cs
+++ b/TraktAPI/DataStructures/TraktListItem.cs
@@ -17,6 +17,9 @@ namespace TraktAPI.DataStructures
         [DataMember(Name = "listed_at")]
         public string ListedAt { get; set; }
 
+        [DataMember( Name = "notes" )]
+        public string Notes { get; set; }
+
         [DataMember(Name = "type")]
         public string Type { get; set; }
 

--- a/TraktAPI/DataStructures/TraktMovieId.cs
+++ b/TraktAPI/DataStructures/TraktMovieId.cs
@@ -1,18 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace TraktAPI.DataStructures
 {
-    [DataContract]
-    public class TraktMovieId : TraktId
-    {
-        [DataMember(Name = "imdb")]
-        public string Imdb { get; set; }
+  [DataContract]
+  public class TraktMovieId : TraktId
+  {
+    [DataMember( Name = "imdb" )]
+    public string Imdb { get; set; }
 
-        [DataMember(Name = "tmdb")]
-        public int? Tmdb { get; set; }
-    }
+    [DataMember( Name = "tmdb" )]
+    public int? Tmdb { get; set; }
+
+    [DataMember( Name = "plex" )]
+    public TraktPlexId Plex { get; set; }
+  }
 }

--- a/TraktAPI/DataStructures/TraktMovieSummary.cs
+++ b/TraktAPI/DataStructures/TraktMovieSummary.cs
@@ -3,49 +3,67 @@ using System.Runtime.Serialization;
 
 namespace TraktAPI.DataStructures
 {
-    [DataContract]
-    public class TraktMovieSummary : TraktMovie
-    {
-        [DataMember(Name = "tagline")]
-        public string Tagline { get; set; }
+  [DataContract]
+  public class TraktMovieSummary : TraktMovie
+  {
+    [DataMember( Name = "tagline" )]
+    public string Tagline { get; set; }
 
-        [DataMember(Name = "overview")]
-        public string Overview { get; set; }
+    [DataMember( Name = "overview" )]
+    public string Overview { get; set; }
 
-        [DataMember(Name = "released")]
-        public string Released { get; set; }
+    [DataMember( Name = "released" )]
+    public string Released { get; set; }
 
-        [DataMember(Name = "runtime")]
-        public int? Runtime { get; set; }
+    [DataMember( Name = "runtime" )]
+    public int? Runtime { get; set; }
 
-        [DataMember(Name = "trailer")]
-        public string Trailer { get; set; }
+    [DataMember( Name = "trailer" )]
+    public string Trailer { get; set; }
 
-        [DataMember(Name = "updated_at")]
-        public string UpdatedAt { get; set; }
+    [DataMember( Name = "updated_at" )]
+    public string UpdatedAt { get; set; }
 
-        [DataMember(Name = "homepage")]
-        public string Homepage { get; set; }
+    [DataMember( Name = "homepage" )]
+    public string Homepage { get; set; }
 
-        [DataMember(Name = "certification")]
-        public string Certification { get; set; }
+    [DataMember( Name = "certification" )]
+    public string Certification { get; set; }
 
-        [DataMember(Name = "rating")]
-        public double? Rating { get; set; }
+    [DataMember( Name = "rating" )]
+    public double? Rating { get; set; }
 
-        [DataMember(Name = "votes")]
-        public int Votes { get; set; }
+    [DataMember( Name = "votes" )]
+    public int Votes { get; set; }
 
-        [DataMember(Name = "language")]
-        public string Language { get; set; }
+    [DataMember( Name = "country" )]
+    public string Country { get; set; }
 
-        [DataMember(Name = "comment_count")]
-        public int CommentCount { get; set; }
+    [DataMember( Name = "language" )]
+    public string Language { get; set; }
 
-        [DataMember(Name = "available_translations")]
-        public List<string> AvailableTranslations { get; set; }
+    [DataMember( Name = "languages" )]
+    public List<string> Languages { get; set; }
 
-        [DataMember(Name = "genres")]
-        public List<string> Genres { get; set; }
-    }
+    [DataMember( Name = "comment_count" )]
+    public int CommentCount { get; set; }
+
+    [DataMember( Name = "available_translations" )]
+    public List<string> AvailableTranslations { get; set; }
+
+    [DataMember( Name = "genres" )]
+    public List<string> Genres { get; set; }
+
+    [DataMember( Name = "subgenres" )]
+    public List<string> SubGenres { get; set; }
+
+    [DataMember( Name = "after_credits" )]
+    public bool AfterCredits { get; set; }
+
+    [DataMember( Name = "during_credits" )]
+    public bool DuringCredits { get; set; }
+
+    [DataMember( Name = "original_title" )]
+    public string OriginalTitle { get; set; }
+  }
 }

--- a/TraktAPI/DataStructures/TraktMovieWatchlist.cs
+++ b/TraktAPI/DataStructures/TraktMovieWatchlist.cs
@@ -16,5 +16,8 @@ namespace TraktAPI.DataStructures
 
     [DataMember( Name = "movie" )]
     public TraktMovieSummary Movie { get; set; }
+
+    [DataMember( Name = "notes" )]
+    public string Notes { get; set; }
   }
 }

--- a/TraktAPI/DataStructures/TraktPlexId.cs
+++ b/TraktAPI/DataStructures/TraktPlexId.cs
@@ -1,0 +1,14 @@
+﻿using System.Runtime.Serialization;
+
+namespace TraktAPI.DataStructures
+{
+  [DataContract]
+  public class TraktPlexId
+  {
+    [DataMember( Name = "guid" )]
+    public string Guid { get; set; }
+
+    [DataMember( Name = "slug" )]
+    public string Slug { get; set; }
+  }
+}

--- a/TraktAPI/DataStructures/TraktSeasonId.cs
+++ b/TraktAPI/DataStructures/TraktSeasonId.cs
@@ -1,24 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace TraktAPI.DataStructures
 {
-    [DataContract]
-    public class TraktSeasonId
-    {
-        [DataMember(Name = "trakt")]
-        public int? Trakt { get; set; }
+  [DataContract]
+  public class TraktSeasonId
+  {
+    [DataMember( Name = "trakt" )]
+    public int? Trakt { get; set; }
 
-        [DataMember(Name = "tmdb")]
-        public int? Tmdb { get; set; }
+    [DataMember( Name = "tmdb" )]
+    public int? Tmdb { get; set; }
 
-        [DataMember(Name = "tvdb")]
-        public int? Tvdb { get; set; }
+    [DataMember( Name = "tvdb" )]
+    public int? Tvdb { get; set; }
 
-        [DataMember(Name = "tvrage")]
-        public int? TvRage { get; set; }
-    }
+    [DataMember( Name = "plex" )]
+    public TraktPlexId Plex { get; set; }
+  }
 }

--- a/TraktAPI/DataStructures/TraktSeasonSummary.cs
+++ b/TraktAPI/DataStructures/TraktSeasonSummary.cs
@@ -3,34 +3,40 @@ using System.Runtime.Serialization;
 
 namespace TraktAPI.DataStructures
 {
-    [DataContract]
-    public class TraktSeasonSummary : TraktSeason
-    {
-        [DataMember(Name = "rating")]
-        public double? Rating { get; set; }
+  [DataContract]
+  public class TraktSeasonSummary : TraktSeason
+  {
+    [DataMember( Name = "rating" )]
+    public double? Rating { get; set; }
 
-        [DataMember(Name = "votes")]
-        public int Votes { get; set; }
+    [DataMember( Name = "votes" )]
+    public int Votes { get; set; }
 
-        [DataMember(Name = "episode_count")]
-        public int EpisodeCount { get; set; }
+    [DataMember( Name = "episode_count" )]
+    public int EpisodeCount { get; set; }
 
-        [DataMember(Name = "aired_episodes")]
-        public int EpisodeAiredCount { get; set; }
+    [DataMember( Name = "aired_episodes" )]
+    public int EpisodeAiredCount { get; set; }
 
-        [DataMember(Name = "overview")]
-        public string Overview { get; set; }
+    [DataMember( Name = "overview" )]
+    public string Overview { get; set; }
 
-        [DataMember(Name = "title")]
-        public string Title { get; set; }
+    [DataMember( Name = "title" )]
+    public string Title { get; set; }
 
-        [DataMember(Name = "network")]
-        public string Network { get; set; }
+    [DataMember( Name = "original_title" )]
+    public string OriginalTitle { get; set; }
 
-        [DataMember(Name = "first_aired")]
-        public string FirstAired { get; set; }
+    [DataMember( Name = "network" )]
+    public string Network { get; set; }
 
-        [DataMember(Name = "episodes")]
-        public IEnumerable<TraktEpisodeSummary> Episodes { get; set; }
-    }
+    [DataMember( Name = "first_aired" )]
+    public string FirstAired { get; set; }
+
+    [DataMember( Name = "total_runtime" )]
+    public int? TotalRuntime { get; set; }
+
+    [DataMember( Name = "episodes" )]
+    public IEnumerable<TraktEpisodeSummary> Episodes { get; set; }
+  }
 }

--- a/TraktAPI/DataStructures/TraktShowId.cs
+++ b/TraktAPI/DataStructures/TraktShowId.cs
@@ -1,24 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace TraktAPI.DataStructures
 {
-    [DataContract]
-    public class TraktShowId : TraktId
-    {
-        [DataMember(Name = "imdb")]
-        public string Imdb { get; set; }
+  [DataContract]
+  public class TraktShowId : TraktId
+  {
+    [DataMember( Name = "imdb" )]
+    public string Imdb { get; set; }
 
-        [DataMember(Name = "tmdb")]
-        public int? Tmdb { get; set; }
+    [DataMember( Name = "tmdb" )]
+    public int? Tmdb { get; set; }
 
-        [DataMember(Name = "tvdb")]
-        public int? Tvdb { get; set; }
+    [DataMember( Name = "tvdb" )]
+    public int? Tvdb { get; set; }
 
-        [DataMember(Name = "tvrage")]
-        public int? TvRage { get; set; }
-    }
+    [DataMember( Name = "plex" )]
+    public TraktPlexId Plex { get; set; }
+  }
 }

--- a/TraktAPI/DataStructures/TraktShowSummary.cs
+++ b/TraktAPI/DataStructures/TraktShowSummary.cs
@@ -1,79 +1,91 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace TraktAPI.DataStructures
 {
+  [DataContract]
+  public class TraktShowSummary : TraktShow
+  {
+    [DataMember( Name = "first_aired" )]
+    public string FirstAired { get; set; }
+
+    [DataMember( Name = "airs" )]
+    public AirDate Airs { get; set; }
+
+    [DataMember( Name = "runtime" )]
+    public int? Runtime { get; set; }
+
+    [DataMember( Name = "total_runtime" )]
+    public int? TotalRuntime { get; set; }
+
+    [DataMember( Name = "certification" )]
+    public string Certification { get; set; }
+
+    [DataMember( Name = "network" )]
+    public string Network { get; set; }
+
+    [DataMember( Name = "country" )]
+    public string Country { get; set; }
+
+    [DataMember( Name = "updated_at" )]
+    public string UpdatedAt { get; set; }
+
+    [DataMember( Name = "overview" )]
+    public string Overview { get; set; }
+
+    [DataMember( Name = "trailer" )]
+    public string Trailer { get; set; }
+
+    [DataMember( Name = "homepage" )]
+    public string Homepage { get; set; }
+
+    [DataMember( Name = "status" )]
+    public string Status { get; set; }
+
+    [DataMember( Name = "rating" )]
+    public double? Rating { get; set; }
+
+    [DataMember( Name = "votes" )]
+    public int Votes { get; set; }
+
+    [DataMember( Name = "language" )]
+    public string Language { get; set; }
+
+    [DataMember( Name = "languages" )]
+    public List<string> Languages { get; set; }
+
+    [DataMember( Name = "comment_count" )]
+    public int CommentCount { get; set; }
+
+    [DataMember( Name = "available_translations" )]
+    public List<string> AvailableTranslations { get; set; }
+
+    [DataMember( Name = "genres" )]
+    public List<string> Genres { get; set; }
+
+    [DataMember( Name = "subgenres" )]
+    public List<string> SubGenres { get; set; }
+
+    [DataMember( Name = "aired_episodes" )]
+    public int AiredEpisodes { get; set; }
+
+    [DataMember( Name = "original_title" )]
+    public string OriginalTitle { get; set; }
+
+    [DataMember( Name = "tagline" )]
+    public string Tagline { get; set; }
+
     [DataContract]
-    public class TraktShowSummary : TraktShow
+    public class AirDate
     {
-        [DataMember(Name = "first_aired")]
-        public string FirstAired { get; set; }
+      [DataMember( Name = "day" )]
+      public string Day { get; set; }
 
-        [DataMember(Name = "airs")]
-        public AirDate Airs { get; set; }
+      [DataMember( Name = "time" )]
+      public string Time { get; set; }
 
-        [DataMember(Name = "runtime")]
-        public int? Runtime { get; set; }
-
-        [DataMember(Name = "certification")]
-        public string Certification { get; set; }
-
-        [DataMember(Name = "network")]
-        public string Network { get; set; }
-
-        [DataMember(Name = "country")]
-        public string Country { get; set; }
-
-        [DataMember(Name = "updated_at")]
-        public string UpdatedAt { get; set; }
-
-        [DataMember(Name = "overview")]
-        public string Overview { get; set; }
-
-        [DataMember(Name = "trailer")]
-        public string Trailer { get; set; }
-
-        [DataMember(Name = "homepage")]
-        public string Homepage { get; set; }
-
-        [DataMember(Name = "status")]
-        public string Status { get; set; }
-
-        [DataMember(Name = "rating")]
-        public double? Rating { get; set; }
-
-        [DataMember(Name = "votes")]
-        public int Votes { get; set; }
-
-        [DataMember(Name = "language")]
-        public string Language { get; set; }
-
-        [DataMember(Name = "comment_count")]
-        public int CommentCount { get; set; }
-
-        [DataMember(Name = "available_translations")]
-        public List<string> AvailableTranslations { get; set; }
-
-        [DataMember(Name = "genres")]
-        public List<string> Genres { get; set; }
-
-        [DataMember(Name = "aired_episodes")]
-        public int AiredEpisodes { get; set; }
-
-        [DataContract]
-        public class AirDate
-        {
-            [DataMember(Name = "day")]
-            public string Day { get; set; }
-
-            [DataMember(Name = "time")]
-            public string Time { get; set; }
-
-            [DataMember(Name = "timezone")]
-            public string Timezone { get; set; }
-        }
+      [DataMember( Name = "timezone" )]
+      public string Timezone { get; set; }
     }
+  }
 }

--- a/TraktAPI/DataStructures/TraktShowWatchlist.cs
+++ b/TraktAPI/DataStructures/TraktShowWatchlist.cs
@@ -16,5 +16,8 @@ namespace TraktAPI.DataStructures
 
     [DataMember( Name = "show" )]
     public TraktShowSummary Show { get; set; }
+
+    [DataMember( Name = "notes" )]
+    public string Notes { get; set; }
   }
 }

--- a/TraktAPI/TraktAPI.csproj
+++ b/TraktAPI/TraktAPI.csproj
@@ -55,6 +55,7 @@
     <Compile Include="DataStructures\TraktListsPopular.cs" />
     <Compile Include="DataStructures\TraktListsTrending.cs" />
     <Compile Include="DataStructures\TraktListTrending.cs" />
+    <Compile Include="DataStructures\TraktPlexId.cs" />
     <Compile Include="DataStructures\TraktMediaInfo.cs" />
     <Compile Include="DataStructures\TraktMovieCalendar.cs" />
     <Compile Include="DataStructures\TraktShowCalendar.cs" />

--- a/TraktPlugin/Cache/TraktCache.cs
+++ b/TraktPlugin/Cache/TraktCache.cs
@@ -306,6 +306,9 @@ namespace TraktPlugin
               _CollectedMovies = _CollectedMovies.Concat( onlineItems.Items );
             }
 
+            // cleanse any bad entries (WTF trakt.tv?)
+            _CollectedMovies = _CollectedMovies.Where(cm => cm?.Movie?.Ids?.Trakt > 0);
+
             // save to local file cache
             SaveFileCache( MoviesCollectedFile, _CollectedMovies.ToList().ToJSON() );
 

--- a/TraktPlugin/Cache/TraktCache.cs
+++ b/TraktPlugin/Cache/TraktCache.cs
@@ -366,7 +366,7 @@ namespace TraktPlugin
             TraktLogger.Info("Movie ratings cache is out of date, requesting updated data. Local Date = '{0}', Online Date = '{1}'", TraktSettings.LastSyncActivities.Movies.Rating ?? "<empty>", lastSyncActivities.Movies.Rating ?? "<empty>");
 
             // we get from online, local cache is not up to date
-            var onlineItems = TraktAPI.TraktAPI.GetRatedMovies(page: 1, maxItems: 500);
+            var onlineItems = TraktAPI.TraktAPI.GetRatedMovies(page: 1, maxItems: 250);
             if (onlineItems == null || onlineItems.Items == null)
                 return null;
 
@@ -374,7 +374,7 @@ namespace TraktPlugin
 
             for (int page = 2; page <= onlineItems.TotalPages; page++)
             {
-                onlineItems = TraktAPI.TraktAPI.GetRatedMovies(page, maxItems: 500);
+                onlineItems = TraktAPI.TraktAPI.GetRatedMovies(page, maxItems: 250);
                 if (onlineItems == null || onlineItems.Items == null)
                     break;
 
@@ -792,7 +792,7 @@ namespace TraktPlugin
             TraktLogger.Info("TV episode ratings cache is out of date, requesting updated data. Local Date = '{0}', Online Date = '{1}'", TraktSettings.LastSyncActivities.Episodes.Rating ?? "<empty>", lastSyncActivities.Episodes.Rating ?? "<empty>");
 
             // we get from online, local cache is not up to date
-            var onlineItems = TraktAPI.TraktAPI.GetRatedEpisodes(page: 1, maxItems: 1000);
+            var onlineItems = TraktAPI.TraktAPI.GetRatedEpisodes(page: 1, maxItems: 250);
             if (onlineItems == null || onlineItems.Items == null)
                 return null;
 
@@ -800,7 +800,7 @@ namespace TraktPlugin
 
             for (int page = 2; page <= onlineItems.TotalPages; page++)
             {
-                onlineItems = TraktAPI.TraktAPI.GetRatedEpisodes(page, maxItems: 1000);
+                onlineItems = TraktAPI.TraktAPI.GetRatedEpisodes(page, maxItems: 250);
                 if (onlineItems == null || onlineItems.Items == null)
                     break;
 

--- a/TraktPlugin/GUI/GUICommon.cs
+++ b/TraktPlugin/GUI/GUICommon.cs
@@ -754,7 +754,6 @@ namespace TraktPlugin.GUI
                     Imdb = episode.Ids.Imdb.ToNullIfEmpty(),
                     Tmdb = episode.Ids.Tmdb,
                     Tvdb = episode.Ids.Tvdb,
-                    TvRage = episode.Ids.TvRage
                 },
                 Title = episode.Title,
                 Season = episode.Season,

--- a/TraktPlugin/GUI/GUICommon.cs
+++ b/TraktPlugin/GUI/GUICommon.cs
@@ -600,7 +600,6 @@ namespace TraktPlugin.GUI
                     Trakt = show.Ids.Trakt,
                     Imdb = show.Ids.Imdb.ToNullIfEmpty(),
                     Tmdb = show.Ids.Tmdb,
-                    TvRage = show.Ids.TvRage,
                     Tvdb = show.Ids.Tvdb
                 },
                 Title = show.Title,
@@ -835,7 +834,6 @@ namespace TraktPlugin.GUI
                         Imdb = objShow.Ids.Imdb.ToNullIfEmpty(),
                         Tmdb = objShow.Ids.Tmdb,
                         Tvdb = objShow.Ids.Tvdb,
-                        TvRage = objShow.Ids.TvRage
                     },
                     Title = show.Title,
                     Year = show.Year
@@ -875,7 +873,6 @@ namespace TraktPlugin.GUI
                         Imdb = objShow.Ids.Imdb.ToNullIfEmpty(),
                         Tmdb = objShow.Ids.Tmdb,
                         Tvdb = objShow.Ids.Tvdb,
-                        TvRage = objShow.Ids.TvRage
                     },
                     Title = show.Title,
                     Year = show.Year,
@@ -922,7 +919,6 @@ namespace TraktPlugin.GUI
                         Imdb = objShow.Ids.Imdb.ToNullIfEmpty(),
                         Tmdb = objShow.Ids.Tmdb,
                         Tvdb = objShow.Ids.Tvdb,
-                        TvRage = objShow.Ids.TvRage
                     },
                     Title = show.Title,
                     Year = show.Year
@@ -962,7 +958,6 @@ namespace TraktPlugin.GUI
                         Imdb = objShow.Ids.Imdb.ToNullIfEmpty(),
                         Tmdb = objShow.Ids.Tmdb,
                         Tvdb = objShow.Ids.Tvdb,
-                        TvRage = objShow.Ids.TvRage
                     },
                     Title = show.Title,
                     Year = show.Year,
@@ -1450,7 +1445,6 @@ namespace TraktPlugin.GUI
         {
             GUIUtils.SetProperty("#Trakt.Season.TmdbId", string.Empty);
             GUIUtils.SetProperty("#Trakt.Season.TvdbId", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.TvRageId", string.Empty);
             GUIUtils.SetProperty("#Trakt.Season.Number", string.Empty);
             GUIUtils.SetProperty("#Trakt.Season.Overview", string.Empty);
             GUIUtils.SetProperty("#Trakt.Season.Title", string.Empty);
@@ -1476,7 +1470,6 @@ namespace TraktPlugin.GUI
         {
             SetProperty("#Trakt.Season.TmdbId", season.Ids.Tmdb);
             SetProperty("#Trakt.Season.TvdbId", season.Ids.Tvdb);
-            SetProperty("#Trakt.Season.TvRageId", season.Ids.TvRage);
             SetProperty("#Trakt.Season.Number", season.Number);            
             SetProperty("#Trakt.Season.Url", string.Format("http://trakt.tv/shows/{0}/seasons/{1}", show.Ids.Slug, season.Number));
             //SetProperty("#Trakt.Season.PosterImageFilename", season.Images == null ? string.Empty : season.Images.Poster.LocalImageFilename(ArtworkType.SeasonPoster));
@@ -1504,7 +1497,6 @@ namespace TraktPlugin.GUI
             GUIUtils.SetProperty("#Trakt.Show.ImdbId", string.Empty);
             GUIUtils.SetProperty("#Trakt.Show.TvdbId", string.Empty);
             GUIUtils.SetProperty("#Trakt.Show.TmdbId", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.TvRageId", string.Empty);
             GUIUtils.SetProperty("#Trakt.Show.Title", string.Empty);
             GUIUtils.SetProperty("#Trakt.Show.Language", string.Empty);
             GUIUtils.SetProperty("#Trakt.Show.Url", string.Empty);
@@ -1548,7 +1540,6 @@ namespace TraktPlugin.GUI
             SetProperty("#Trakt.Show.ImdbId", show.Ids.Imdb);
             SetProperty("#Trakt.Show.TvdbId", show.Ids.Tvdb);
             SetProperty("#Trakt.Show.TmdbId", show.Ids.Tmdb);
-            SetProperty("#Trakt.Show.TvRageId", show.Ids.TvRage);
             SetProperty("#Trakt.Show.Title", show.Title.RemapHighOrderChars());
             SetProperty("#Trakt.Show.Language", Translation.GetLanguageFromISOCode(show.Language));
             SetProperty("#Trakt.Show.Url", string.Format("http://trakt.tv/shows/{0}", show.Ids.Slug));
@@ -2336,7 +2327,6 @@ namespace TraktPlugin.GUI
                 MediaType = MediaItemType.Show,
                 IMDb = show.Ids.Imdb.ToNullIfEmpty(),
                 TVDb = show.Ids.Tvdb.ToString(),
-                TVRage = show.Ids.TvRage.ToString(),
                 TMDb = show.Ids.Tmdb.ToString(),
                 Plot = show.Overview,
                 Poster = TmdbCache.GetShowPosterFilename(showImages),
@@ -2397,7 +2387,6 @@ namespace TraktPlugin.GUI
                 IMDb = show.Ids.Imdb.ToNullIfEmpty(),
                 TMDb = show.Ids.Tmdb.ToString(),
                 TVDb = show.Ids.Tvdb.ToString(),
-                TVRage = show.Ids.TvRage.ToString(),
                 Plot = show.Overview,
                 Poster = TmdbCache.GetShowPosterFilename(showImages),
                 Title = show.Title,
@@ -2419,7 +2408,6 @@ namespace TraktPlugin.GUI
                 IMDb = show.Ids.Imdb.ToNullIfEmpty(),
                 TMDb = show.Ids.Tmdb.ToString(),
                 TVDb = show.Ids.Tvdb.ToString(),
-                TVRage = show.Ids.TvRage.ToString(),
                 Plot = show.Overview,
                 Poster = TmdbCache.GetShowPosterFilename(showImages),
                 Title = show.Title,

--- a/TraktPlugin/GUI/GUICommon.cs
+++ b/TraktPlugin/GUI/GUICommon.cs
@@ -1382,270 +1382,291 @@ namespace TraktPlugin.GUI
 
         internal static void ClearMovieProperties()
         {
-            GUIUtils.SetProperty("#Trakt.Movie.Id", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Tmdb", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Slug", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Imdb", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Certification", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Language", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Overview", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Released", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Runtime", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Tagline", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Title", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Trailer", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Url", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Year", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Genres", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.PosterImageFilename", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.FanartImageFilename", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.InCollection", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.InWatchList", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Plays", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Watched", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Rating", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Ratings.Icon", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Ratings.Percentage", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.Ratings.Votes", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Movie.CommentCount", string.Empty);
+          GUIUtils.SetProperty( "#Trakt.Movie.Id", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Tmdb", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Slug", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Imdb", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Certification", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Language", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Overview", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Released", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Runtime", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Tagline", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Title", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Trailer", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Url", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Year", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Genres", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.PosterImageFilename", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.FanartImageFilename", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.InCollection", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.InWatchList", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Plays", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Watched", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Rating", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Ratings.Icon", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Ratings.Percentage", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Ratings.Votes", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.CommentCount", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.Country", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.SubGenres", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.AfterCredits", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.DuringCredits", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.OriginalTitle", string.Empty );
         }
 
-        internal static void SetMovieProperties(TraktMovieSummary movie)
+        internal static void SetMovieProperties( TraktMovieSummary movie )
         {
-            if (movie == null) return;
+          if ( movie == null )
+            return;
 
-            SetProperty("#Trakt.Movie.Id", movie.Ids.Trakt);
-            SetProperty("#Trakt.Movie.ImdbId", movie.Ids.Imdb);
-            SetProperty("#Trakt.Movie.TmdbId", movie.Ids.Tmdb);
-            SetProperty("#Trakt.Movie.Slug", movie.Ids.Slug);
-            SetProperty("#Trakt.Movie.Certification", movie.Certification);
-            SetProperty("#Trakt.Movie.Overview", movie.Overview.ToNullIfEmpty() == null ? Translation.NoMovieSummary : movie.Overview.RemapHighOrderChars());
-            SetProperty("#Trakt.Movie.Released", movie.Released);
-            SetProperty("#Trakt.Movie.Language", Translation.GetLanguageFromISOCode(movie.Language));
-            SetProperty("#Trakt.Movie.Runtime", movie.Runtime);
-            SetProperty("#Trakt.Movie.Tagline", movie.Tagline);
-            SetProperty("#Trakt.Movie.Title", movie.Title.RemapHighOrderChars());
-            SetProperty("#Trakt.Movie.Trailer", movie.Trailer);
-            SetProperty("#Trakt.Movie.Url", string.Format("http://trakt.tv/movies/{0}", movie.Ids.Slug));
-            SetProperty("#Trakt.Movie.Year", movie.Year);
-            SetProperty("#Trakt.Movie.Genres", TraktGenres.Translate(movie.Genres));
-            SetProperty("#Trakt.Movie.InCollection", movie.IsCollected());
-            SetProperty("#Trakt.Movie.InWatchList", movie.IsWatchlisted());
-            SetProperty("#Trakt.Movie.Plays", movie.Plays());
-            SetProperty("#Trakt.Movie.Watched", movie.IsWatched());
-            SetProperty("#Trakt.Movie.Rating", movie.UserRating());
-            SetProperty("#Trakt.Movie.Ratings.Percentage", movie.Rating.ToPercentage());
-            SetProperty("#Trakt.Movie.Ratings.Votes", movie.Votes);
-            SetProperty("#Trakt.Movie.Ratings.Icon", (movie.Rating >= 6) ? "love" : "hate");
-            SetProperty("#Trakt.Movie.CommentCount", movie.CommentCount);
+          SetProperty( "#Trakt.Movie.Id", movie.Ids.Trakt );
+          SetProperty( "#Trakt.Movie.ImdbId", movie.Ids.Imdb );
+          SetProperty( "#Trakt.Movie.TmdbId", movie.Ids.Tmdb );
+          SetProperty( "#Trakt.Movie.Slug", movie.Ids.Slug );
+          SetProperty( "#Trakt.Movie.Certification", movie.Certification );
+          SetProperty( "#Trakt.Movie.Overview", movie.Overview.ToNullIfEmpty() == null ? Translation.NoMovieSummary : movie.Overview.RemapHighOrderChars() );
+          SetProperty( "#Trakt.Movie.Released", movie.Released );
+          SetProperty( "#Trakt.Movie.Language", Translation.GetLanguageFromISOCode( movie.Language ) );
+          SetProperty( "#Trakt.Movie.Runtime", movie.Runtime );
+          SetProperty( "#Trakt.Movie.Tagline", movie.Tagline );
+          SetProperty( "#Trakt.Movie.Title", movie.Title.RemapHighOrderChars() );
+          SetProperty( "#Trakt.Movie.Trailer", movie.Trailer );
+          SetProperty( "#Trakt.Movie.Url", string.Format( "http://trakt.tv/movies/{0}", movie.Ids.Slug ) );
+          SetProperty( "#Trakt.Movie.Year", movie.Year );
+          SetProperty( "#Trakt.Movie.Genres", TraktGenres.Translate( movie.Genres ) );
+          SetProperty( "#Trakt.Movie.InCollection", movie.IsCollected() );
+          SetProperty( "#Trakt.Movie.InWatchList", movie.IsWatchlisted() );
+          SetProperty( "#Trakt.Movie.Plays", movie.Plays() );
+          SetProperty( "#Trakt.Movie.Watched", movie.IsWatched() );
+          SetProperty( "#Trakt.Movie.Rating", movie.UserRating() );
+          SetProperty( "#Trakt.Movie.Ratings.Percentage", movie.Rating.ToPercentage() );
+          SetProperty( "#Trakt.Movie.Ratings.Votes", movie.Votes );
+          SetProperty( "#Trakt.Movie.Ratings.Icon", ( movie.Rating >= 6 ) ? "love" : "hate" );
+          SetProperty( "#Trakt.Movie.CommentCount", movie.CommentCount );
+          SetProperty( "#Trakt.Movie.Country", movie.Country );
+          SetProperty( "#Trakt.Movie.SubGenres", movie.SubGenres );
+          SetProperty( "#Trakt.Movie.AfterCredits", movie.AfterCredits );
+          SetProperty( "#Trakt.Movie.DuringCredits", movie.DuringCredits );
+          SetProperty( "#Trakt.Movie.OriginalTitle", movie.OriginalTitle );
         }
 
         internal static void ClearSeasonProperties()
         {
-            GUIUtils.SetProperty("#Trakt.Season.TmdbId", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.TvdbId", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.Number", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.Overview", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.Title", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.Network", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.FirstAired", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.FirstAiredLocalized", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.EpisodeCount", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.EpisodeAiredCount", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.Watched", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.InCollection", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.InWatchList", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.Collected", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.Plays", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.Rating", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.Ratings.Icon", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.Ratings.Percentage", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.Ratings.Votes", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.Url", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Season.PosterImageFilename", string.Empty);
+          GUIUtils.SetProperty( "#Trakt.Season.TmdbId", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.TvdbId", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.Number", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.Overview", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.Title", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.Network", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.FirstAired", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.FirstAiredLocalized", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.EpisodeCount", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.EpisodeAiredCount", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.Watched", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.InCollection", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.InWatchList", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.Collected", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.Plays", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.Rating", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.Ratings.Icon", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.Ratings.Percentage", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.Ratings.Votes", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.Url", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.PosterImageFilename", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.OriginalTitle", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Season.TotalRuntime", string.Empty );
         }
 
-        internal static void SetSeasonProperties(TraktShowSummary show, TraktSeasonSummary season)
+        internal static void SetSeasonProperties( TraktShowSummary show, TraktSeasonSummary season )
         {
-            SetProperty("#Trakt.Season.TmdbId", season.Ids.Tmdb);
-            SetProperty("#Trakt.Season.TvdbId", season.Ids.Tvdb);
-            SetProperty("#Trakt.Season.Number", season.Number);            
-            SetProperty("#Trakt.Season.Url", string.Format("http://trakt.tv/shows/{0}/seasons/{1}", show.Ids.Slug, season.Number));
-            //SetProperty("#Trakt.Season.PosterImageFilename", season.Images == null ? string.Empty : season.Images.Poster.LocalImageFilename(ArtworkType.SeasonPoster));
-            SetProperty("#Trakt.Season.EpisodeCount", season.EpisodeCount);
-            SetProperty("#Trakt.Season.EpisodeAiredCount", season.EpisodeAiredCount);
-            SetProperty("#Trakt.Season.Title", season.Title ?? string.Format("{0} {1}", Translation.Season, season.Number));
-            SetProperty("#Trakt.Season.Overview", season.Overview ?? show.Overview);
-            SetProperty("#Trakt.Season.Network", season.Network);
-            SetProperty("#Trakt.Season.FirstAired", season.FirstAired.FromISO8601().ToShortDateString());
-            SetProperty("#Trakt.Season.FirstAiredLocalized", season.FirstAired.FromISO8601().ToLocalTime().ToShortDateString());
-            SetProperty("#Trakt.Season.Watched", season.IsWatched(show));
-            SetProperty("#Trakt.Season.Plays", season.Plays(show));
-            SetProperty("#Trakt.Season.InCollection", season.IsCollected(show));
-            SetProperty("#Trakt.Season.InWatchList", season.IsWatchlisted(show));
-            SetProperty("#Trakt.Season.Collected", season.Collected(show));
-            SetProperty("#Trakt.Season.Rating", season.UserRating(show));
-            SetProperty("#Trakt.Season.Ratings.Percentage", season.Rating.ToPercentage());
-            SetProperty("#Trakt.Season.Ratings.Votes", season.Votes);
-            SetProperty("#Trakt.Season.Ratings.Icon", (season.Rating >= 6) ? "love" : "hate");
+          SetProperty( "#Trakt.Season.TmdbId", season.Ids.Tmdb );
+          SetProperty( "#Trakt.Season.TvdbId", season.Ids.Tvdb );
+          SetProperty( "#Trakt.Season.Number", season.Number );
+          SetProperty( "#Trakt.Season.Url", string.Format( "http://trakt.tv/shows/{0}/seasons/{1}", show.Ids.Slug, season.Number ) );
+          SetProperty( "#Trakt.Season.EpisodeCount", season.EpisodeCount );
+          SetProperty( "#Trakt.Season.EpisodeAiredCount", season.EpisodeAiredCount );
+          SetProperty( "#Trakt.Season.Title", season.Title ?? string.Format( "{0} {1}", Translation.Season, season.Number ) );
+          SetProperty( "#Trakt.Season.Overview", season.Overview ?? show.Overview );
+          SetProperty( "#Trakt.Season.Network", season.Network );
+          SetProperty( "#Trakt.Season.FirstAired", season.FirstAired.FromISO8601().ToShortDateString() );
+          SetProperty( "#Trakt.Season.FirstAiredLocalized", season.FirstAired.FromISO8601().ToLocalTime().ToShortDateString() );
+          SetProperty( "#Trakt.Season.Watched", season.IsWatched( show ) );
+          SetProperty( "#Trakt.Season.Plays", season.Plays( show ) );
+          SetProperty( "#Trakt.Season.InCollection", season.IsCollected( show ) );
+          SetProperty( "#Trakt.Season.InWatchList", season.IsWatchlisted( show ) );
+          SetProperty( "#Trakt.Season.Collected", season.Collected( show ) );
+          SetProperty( "#Trakt.Season.Rating", season.UserRating( show ) );
+          SetProperty( "#Trakt.Season.Ratings.Percentage", season.Rating.ToPercentage() );
+          SetProperty( "#Trakt.Season.Ratings.Votes", season.Votes );
+          SetProperty( "#Trakt.Season.Ratings.Icon", ( season.Rating >= 6 ) ? "love" : "hate" );
+          SetProperty( "#Trakt.Season.OriginalTitle", season.OriginalTitle );
+          SetProperty( "#Trakt.Season.TotalRuntime", season.TotalRuntime );
         }
 
         internal static void ClearShowProperties()
         {
-            GUIUtils.SetProperty("#Trakt.Show.Id", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.ImdbId", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.TvdbId", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.TmdbId", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Title", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Language", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Url", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.AirDay", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.AirDayLocalized", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.AirTime", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.AirTimeLocalized", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.AirTimezone", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.AirTimezoneWindows", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Certification", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Country", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.FirstAired", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.FirstAiredLocalized", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Network", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Overview", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Runtime", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Year", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Status", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Genres", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.InWatchList", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.InCollection", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Collected", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Watched", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.AiredEpisodes", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Plays", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Rating", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Ratings.Icon", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Ratings.Percentage", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.Ratings.Votes", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.FanartImageFilename", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.PosterImageFilename", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.BannerImageFilename", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Show.CommentCount", string.Empty);
+          GUIUtils.SetProperty( "#Trakt.Show.Id", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.ImdbId", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.TvdbId", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.TmdbId", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Title", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Language", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Url", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.AirDay", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.AirDayLocalized", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.AirTime", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.AirTimeLocalized", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.AirTimezone", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.AirTimezoneWindows", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Certification", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Country", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.FirstAired", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.FirstAiredLocalized", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Network", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Overview", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Runtime", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Year", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Status", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Genres", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.InWatchList", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.InCollection", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Collected", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Watched", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.AiredEpisodes", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Plays", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Rating", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Ratings.Icon", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Ratings.Percentage", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Ratings.Votes", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.FanartImageFilename", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.PosterImageFilename", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.BannerImageFilename", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.CommentCount", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.Tagline", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.OriginalTitle", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.SubGenres", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.TotalRuntime", string.Empty );
         }
 
         internal static void SetShowProperties(TraktShowSummary show)
         {
-            if (show == null) return;
+          if ( show == null )
+            return;
 
-            SetProperty("#Trakt.Show.Id", show.Ids.Trakt);
-            SetProperty("#Trakt.Show.ImdbId", show.Ids.Imdb);
-            SetProperty("#Trakt.Show.TvdbId", show.Ids.Tvdb);
-            SetProperty("#Trakt.Show.TmdbId", show.Ids.Tmdb);
-            SetProperty("#Trakt.Show.Title", show.Title.RemapHighOrderChars());
-            SetProperty("#Trakt.Show.Language", Translation.GetLanguageFromISOCode(show.Language));
-            SetProperty("#Trakt.Show.Url", string.Format("http://trakt.tv/shows/{0}", show.Ids.Slug));
-            if (show.Airs != null)
-            {
-                SetProperty("#Trakt.Show.AirDay", show.FirstAired.FromISO8601().ToLocalisedDayOfWeek());
-                SetProperty("#Trakt.Show.AirDayLocalized", show.FirstAired.FromISO8601().ToLocalTime().ToLocalisedDayOfWeek());
-                SetProperty("#Trakt.Show.AirTime", show.FirstAired.FromISO8601().ToShortTimeString());
-                SetProperty("#Trakt.Show.AirTimeLocalized", show.FirstAired.FromISO8601().ToLocalTime().ToShortTimeString());
-                SetProperty("#Trakt.Show.AirTimezone", show.Airs.Timezone);
-                SetProperty("#Trakt.Show.AirTimezoneWindows", show.Airs.Timezone.OlsenToWindowsTimezone());
-            }
-            SetProperty("#Trakt.Show.Certification", show.Certification);
-            SetProperty("#Trakt.Show.Country", show.Country.ToCountryName());
-            SetProperty("#Trakt.Show.FirstAired", show.FirstAired.FromISO8601().ToShortDateString());
-            SetProperty("#Trakt.Show.FirstAiredLocalized", show.FirstAired.FromISO8601().ToLocalTime().ToShortDateString());
-            SetProperty("#Trakt.Show.Network", show.Network);
-            SetProperty("#Trakt.Show.Overview", show.Overview.ToNullIfEmpty() == null ? Translation.NoShowSummary : show.Overview.RemapHighOrderChars());
-            SetProperty("#Trakt.Show.Runtime", show.Runtime);
-            SetProperty("#Trakt.Show.Year", show.Year);
-            SetProperty("#Trakt.Show.Status", show.Status);
-            SetProperty("#Trakt.Show.TranslatedStatus", (show.Status ?? "").Replace(" " ,"").Translate());
-            SetProperty("#Trakt.Show.Genres", TraktGenres.Translate(show.Genres));
-            SetProperty("#Trakt.Show.InWatchList", show.IsWatchlisted());
-            SetProperty("#Trakt.Show.InCollection", show.IsCollected());
-            SetProperty("#Trakt.Show.Collected", show.Collected());
-            SetProperty("#Trakt.Show.Watched", show.IsWatched());
-            SetProperty("#Trakt.Show.AiredEpisodes", show.AiredEpisodes);
-            SetProperty("#Trakt.Show.Plays", show.Plays());
-            SetProperty("#Trakt.Show.Rating", show.UserRating());
-            SetProperty("#Trakt.Show.Ratings.Percentage", show.Rating.ToPercentage());
-            SetProperty("#Trakt.Show.Ratings.Votes", show.Votes);
-            SetProperty("#Trakt.Show.Ratings.Icon", (show.Rating > 6) ? "love" : "hate");
-            SetProperty("#Trakt.Show.CommentCount", show.CommentCount);
-            //if (show.Images != null)
-            //{
-            //    SetProperty("#Trakt.Show.FanartImageFilename", show.Images.Fanart.LocalImageFilename(ArtworkType.ShowFanart));
-            //    SetProperty("#Trakt.Show.PosterImageFilename", show.Images.Poster.LocalImageFilename(ArtworkType.ShowPoster));
-            //    SetProperty("#Trakt.Show.BannerImageFilename", show.Images.Banner.LocalImageFilename(ArtworkType.ShowBanner));
-            //}
+          SetProperty( "#Trakt.Show.Id", show.Ids.Trakt );
+          SetProperty( "#Trakt.Show.ImdbId", show.Ids.Imdb );
+          SetProperty( "#Trakt.Show.TvdbId", show.Ids.Tvdb );
+          SetProperty( "#Trakt.Show.TmdbId", show.Ids.Tmdb );
+          SetProperty( "#Trakt.Show.Title", show.Title.RemapHighOrderChars() );
+          SetProperty( "#Trakt.Show.OriginalTitle", show.OriginalTitle );
+          SetProperty( "#Trakt.Show.Language", Translation.GetLanguageFromISOCode( show.Language ) );
+          SetProperty( "#Trakt.Show.Url", string.Format( "http://trakt.tv/shows/{0}", show.Ids.Slug ) );
+          SetProperty( "#Trakt.Show.AirDay", show.FirstAired.FromISO8601().ToLocalisedDayOfWeek() );
+          SetProperty( "#Trakt.Show.AirDayLocalized", show.FirstAired.FromISO8601().ToLocalTime().ToLocalisedDayOfWeek() );
+          SetProperty( "#Trakt.Show.AirTime", show.FirstAired.FromISO8601().ToShortTimeString() );
+          SetProperty( "#Trakt.Show.AirTimeLocalized", show.FirstAired.FromISO8601().ToLocalTime().ToShortTimeString() );
+          SetProperty( "#Trakt.Show.AirTimezone", show.Airs?.Timezone ?? string.Empty );
+          SetProperty( "#Trakt.Show.AirTimezoneWindows", show.Airs?.Timezone.OlsenToWindowsTimezone() ?? string.Empty );
+          SetProperty( "#Trakt.Show.Certification", show.Certification );
+          SetProperty( "#Trakt.Show.Country", show.Country.ToCountryName() );
+          SetProperty( "#Trakt.Show.FirstAired", show.FirstAired.FromISO8601().ToShortDateString() );
+          SetProperty( "#Trakt.Show.FirstAiredLocalized", show.FirstAired.FromISO8601().ToLocalTime().ToShortDateString() );
+          SetProperty( "#Trakt.Show.Network", show.Network );
+          SetProperty( "#Trakt.Show.Overview", show.Overview.ToNullIfEmpty() == null ? Translation.NoShowSummary : show.Overview.RemapHighOrderChars() );
+          SetProperty( "#Trakt.Show.Runtime", show.Runtime );
+          SetProperty( "#Trakt.Show.TotalRuntime", show.TotalRuntime );
+          SetProperty( "#Trakt.Show.Year", show.Year );
+          SetProperty( "#Trakt.Show.Status", show.Status );
+          SetProperty( "#Trakt.Show.TranslatedStatus", ( show.Status ?? "" ).Replace( " ", "" ).Translate() );
+          SetProperty( "#Trakt.Show.Genres", TraktGenres.Translate( show.Genres ) );
+          SetProperty( "#Trakt.Show.SubGenres", show.SubGenres );
+          SetProperty( "#Trakt.Show.InWatchList", show.IsWatchlisted() );
+          SetProperty( "#Trakt.Show.InCollection", show.IsCollected() );
+          SetProperty( "#Trakt.Show.Collected", show.Collected() );
+          SetProperty( "#Trakt.Show.Watched", show.IsWatched() );
+          SetProperty( "#Trakt.Show.AiredEpisodes", show.AiredEpisodes );
+          SetProperty( "#Trakt.Show.Plays", show.Plays() );
+          SetProperty( "#Trakt.Show.Rating", show.UserRating() );
+          SetProperty( "#Trakt.Show.Ratings.Percentage", show.Rating.ToPercentage() );
+          SetProperty( "#Trakt.Show.Ratings.Votes", show.Votes );
+          SetProperty( "#Trakt.Show.Ratings.Icon", ( show.Rating > 6 ) ? "love" : "hate" );
+          SetProperty( "#Trakt.Show.CommentCount", show.CommentCount );
+          SetProperty( "#Trakt.Show.Tagline", show.Tagline );
         }
 
         internal static void ClearEpisodeProperties()
         {
-            GUIUtils.SetProperty("#Trakt.Episode.Id", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.TvdbId", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.ImdbId", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.TmdbId", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.Number", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.Season", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.FirstAired", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.FirstAiredLocalized", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.FirstAiredLocalizedDayOfWeek", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.FirstAiredLocalizedTime", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.Title", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.Url", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.Overview", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.Runtime", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.InWatchList", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.InCollection", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.Plays", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.Watched", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.Rating", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.Ratings.Icon", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.Ratings.HatedCount", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.Ratings.LovedCount", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.Ratings.Percentage", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.Ratings.Votes", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.EpisodeImageFilename", string.Empty);
-            GUIUtils.SetProperty("#Trakt.Episode.CommentCount", string.Empty);
+          GUIUtils.SetProperty( "#Trakt.Episode.Id", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.TvdbId", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.ImdbId", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.TmdbId", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.Number", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.Season", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.FirstAired", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.FirstAiredLocalized", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.FirstAiredLocalizedDayOfWeek", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.FirstAiredLocalizedTime", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.Title", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.Url", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.Overview", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.Runtime", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.InWatchList", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.InCollection", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.Plays", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.Watched", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.Rating", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.Ratings.Icon", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.Ratings.HatedCount", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.Ratings.LovedCount", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.Ratings.Percentage", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.Ratings.Votes", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.EpisodeImageFilename", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.CommentCount", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.OriginalTitle", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.Released", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.EffectiveReleaseDate", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.EpisodeType", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.AfterCredits", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Episode.DuringCredits", string.Empty );
         }
 
-        internal static void SetEpisodeProperties(TraktShowSummary show, TraktEpisodeSummary episode)
+        internal static void SetEpisodeProperties( TraktShowSummary show, TraktEpisodeSummary episode )
         {
-            if (episode == null) return;
+          if ( episode == null )
+            return;
 
-            SetProperty("#Trakt.Episode.Id", episode.Ids.Trakt);
-            SetProperty("#Trakt.Episode.TvdbId", episode.Ids.Tvdb);
-            SetProperty("#Trakt.Episode.ImdbId", episode.Ids.Imdb);
-            SetProperty("#Trakt.Episode.TmdbId", episode.Ids.Imdb);
-            SetProperty("#Trakt.Episode.Number", episode.Number);
-            SetProperty("#Trakt.Episode.Season", episode.Season);
-            if (episode.FirstAired != null)
-            {
-                // FirstAired is converted to UTC from original countries timezone on trakt
-                SetProperty("#Trakt.Episode.FirstAired", episode.FirstAired.FromISO8601().ToShortDateString());
-                SetProperty("#Trakt.Episode.FirstAiredLocalized", episode.FirstAired.FromISO8601().ToLocalTime().ToShortDateString());
-                SetProperty("#Trakt.Episode.FirstAiredLocalizedDayOfWeek", episode.FirstAired.FromISO8601().ToLocalTime().ToLocalisedDayOfWeek());
-                SetProperty("#Trakt.Episode.FirstAiredLocalizedTime", episode.FirstAired.FromISO8601().ToLocalTime().ToShortTimeString());
-            }
-            SetProperty("#Trakt.Episode.Title", string.IsNullOrEmpty(episode.Title) ? string.Format("{0} {1}", Translation.Episode, episode.Number.ToString()) : episode.Title.RemapHighOrderChars());
-            SetProperty("#Trakt.Episode.Url", string.Format("http://trakt.tv/shows/{0}/seasons/{1}/episodes/{2}", show.Ids.Slug, episode.Season, episode.Number));
-            SetProperty("#Trakt.Episode.Overview", episode.Overview.ToNullIfEmpty() == null ? Translation.NoEpisodeSummary : episode.Overview.RemapHighOrderChars());
-            SetProperty("#Trakt.Episode.Runtime", show.Runtime);
-            SetProperty("#Trakt.Episode.InWatchList", episode.IsWatchlisted());
-            SetProperty("#Trakt.Episode.InCollection", episode.IsCollected(show));
-            SetProperty("#Trakt.Episode.Plays", episode.Plays(show));
-            SetProperty("#Trakt.Episode.Watched", episode.IsWatched(show));
-            SetProperty("#Trakt.Episode.Rating", episode.UserRating(show));
-            SetProperty("#Trakt.Episode.Ratings.Percentage", episode.Rating.ToPercentage());
-            SetProperty("#Trakt.Episode.Ratings.Votes", episode.Votes);
-            SetProperty("#Trakt.Episode.Ratings.Icon", (episode.Rating >= 6) ? "love" : "hate");
-            SetProperty("#Trakt.Episode.CommentCount", episode.CommentCount);
-            //if (episode.Images != null)
-            //{
-            //    SetProperty("#Trakt.Episode.EpisodeImageFilename", episode.Images.ScreenShot.LocalImageFilename(ArtworkType.EpisodeImage));
-            //}
+          SetProperty( "#Trakt.Episode.Id", episode.Ids.Trakt );
+          SetProperty( "#Trakt.Episode.TvdbId", episode.Ids.Tvdb );
+          SetProperty( "#Trakt.Episode.ImdbId", episode.Ids.Imdb );
+          SetProperty( "#Trakt.Episode.TmdbId", episode.Ids.Imdb );
+          SetProperty( "#Trakt.Episode.Number", episode.Number );
+          SetProperty( "#Trakt.Episode.Season", episode.Season );
+          SetProperty( "#Trakt.Episode.Title", string.IsNullOrEmpty( episode.Title ) ? string.Format( "{0} {1}", Translation.Episode, episode.Number.ToString() ) : episode.Title.RemapHighOrderChars() );
+          SetProperty( "#Trakt.Episode.Url", string.Format( "http://trakt.tv/shows/{0}/seasons/{1}/episodes/{2}", show.Ids.Slug, episode.Season, episode.Number ) );
+          SetProperty( "#Trakt.Episode.Overview", episode.Overview.ToNullIfEmpty() == null ? Translation.NoEpisodeSummary : episode.Overview.RemapHighOrderChars() );
+          SetProperty( "#Trakt.Episode.Runtime", show.Runtime );
+          SetProperty( "#Trakt.Episode.InWatchList", episode.IsWatchlisted() );
+          SetProperty( "#Trakt.Episode.InCollection", episode.IsCollected( show ) );
+          SetProperty( "#Trakt.Episode.Plays", episode.Plays( show ) );
+          SetProperty( "#Trakt.Episode.Watched", episode.IsWatched( show ) );
+          SetProperty( "#Trakt.Episode.Rating", episode.UserRating( show ) );
+          SetProperty( "#Trakt.Episode.Ratings.Percentage", episode.Rating.ToPercentage() );
+          SetProperty( "#Trakt.Episode.Ratings.Votes", episode.Votes );
+          SetProperty( "#Trakt.Episode.Ratings.Icon", ( episode.Rating >= 6 ) ? "love" : "hate" );
+          SetProperty( "#Trakt.Episode.CommentCount", episode.CommentCount );
+          SetProperty( "#Trakt.Episode.OriginalTitle", episode.OriginalTitle );
+          SetProperty( "#Trakt.Episode.Released", episode.Released );
+          SetProperty( "#Trakt.Episode.EffectiveReleaseDate", episode.EffectiveReleaseDate );
+          SetProperty( "#Trakt.Episode.EpisodeType", episode.EpisodeType );
+          SetProperty( "#Trakt.Episode.AfterCredits", episode.AfterCredits );
+          SetProperty( "#Trakt.Episode.DuringCredits", episode.DuringCredits );
+
+          // FirstAired is converted to UTC from original countries timezone on trakt
+          SetProperty( "#Trakt.Episode.FirstAired", episode.FirstAired?.FromISO8601().ToShortDateString() ?? string.Empty );
+          SetProperty( "#Trakt.Episode.FirstAiredLocalized", episode.FirstAired?.FromISO8601().ToLocalTime().ToShortDateString() ?? string.Empty );
+          SetProperty( "#Trakt.Episode.FirstAiredLocalizedDayOfWeek", episode.FirstAired?.FromISO8601().ToLocalTime().ToLocalisedDayOfWeek() ?? string.Empty );
+          SetProperty( "#Trakt.Episode.FirstAiredLocalizedTime", episode.FirstAired?.FromISO8601().ToLocalTime().ToShortTimeString() ?? string.Empty );
         }
 
         internal static void ClearPersonProperties()
@@ -1673,16 +1694,6 @@ namespace TraktPlugin.GUI
             SetProperty("#Trakt.Person.TmdbId", person.Ids.TmdbId);
             SetProperty("#Trakt.Person.TvRageId", person.Ids.TvRageId);
             SetProperty("#Trakt.Person.Name", person.Name);
-            //if (person.Images != null)
-            //{
-            //    SetProperty("#Trakt.Person.HeadshotUrl", person.Images.HeadShot.FullSize);
-            //    SetProperty("#Trakt.Person.HeadshotFilename", person.Images.HeadShot.LocalImageFilename(ArtworkType.PersonHeadshot));
-            //    if (person.Images.Fanart != null && System.IO.File.Exists(person.Images.Fanart.LocalImageFilename(ArtworkType.PersonFanart)))
-            //    {
-            //        SetProperty("#Trakt.Person.FanartUrl", person.Images.Fanart.FullSize);
-            //        SetProperty("#Trakt.Person.FanartFilename", person.Images.Fanart.LocalImageFilename(ArtworkType.PersonFanart));
-            //    }
-            //}
             SetProperty("#Trakt.Person.Url", string.Format("http://trakt.tv/people/{0}", person.Ids.Slug));
             SetProperty("#Trakt.Person.Biography", person.Biography ?? Translation.NoPersonBiography.RemapHighOrderChars());
             SetProperty("#Trakt.Person.Birthday", person.Birthday);

--- a/TraktPlugin/GUI/GUIListItems.cs
+++ b/TraktPlugin/GUI/GUIListItems.cs
@@ -1131,14 +1131,18 @@ namespace TraktPlugin.GUI
             }
         }
 
-        private void ClearProperties()
-        {
+          private void ClearProperties()
+          {
+            GUIUtils.SetProperty( "#Trakt.List.ItemType", string.Empty );
+            GUIUtils.SetProperty( "#Trakt.List.Rank", string.Empty );
+            GUIUtils.SetProperty( "#Trakt.List.Notes", string.Empty );
+
             GUICommon.ClearMovieProperties();
             GUICommon.ClearShowProperties();
             GUICommon.ClearSeasonProperties();
             GUICommon.ClearEpisodeProperties();
             GUICommon.ClearPersonProperties();
-        }
+          }
 
         private void PublishEpisodeSkinProperties(TraktListItem item)
         {
@@ -1223,7 +1227,8 @@ namespace TraktPlugin.GUI
             }
             GUIUtils.SetProperty("#Trakt.List.ItemType", SelectedType.ToString());
             GUIUtils.SetProperty("#Trakt.List.Rank", listItem.Rank.ToString());
-        }
+            GUIUtils.SetProperty("#Trakt.List.Notes", listItem.Notes);
+          }
 
         private void UpdateButtonState()
         {

--- a/TraktPlugin/GUI/GUIWatchListEpisodes.cs
+++ b/TraktPlugin/GUI/GUIWatchListEpisodes.cs
@@ -467,22 +467,24 @@ namespace TraktPlugin.GUI
 
         private void ClearProperties()
         {
-            GUICommon.SetProperty("#Trakt.Episode.WatchList.Inserted", string.Empty);
+          GUICommon.SetProperty( "#Trakt.Episode.WatchList.Inserted", string.Empty );
+          GUICommon.SetProperty( "#Trakt.Episode.WatchList.Notes", string.Empty );
 
-            GUICommon.ClearShowProperties();
-            GUICommon.ClearEpisodeProperties();
+          GUICommon.ClearShowProperties();
+          GUICommon.ClearEpisodeProperties();
         }
 
-        private void PublishWatchlistSkinProperties(TraktEpisodeWatchListItem item)
+        private void PublishWatchlistSkinProperties( TraktEpisodeWatchListItem item )
         {
-            // publish watchlist properties
-            GUICommon.SetProperty("#Trakt.Episode.WatchList.Inserted", item.ListedAt.FromISO8601().ToShortDateString());
+          // publish watchlist properties
+          GUICommon.SetProperty( "#Trakt.Episode.WatchList.Inserted", item.ListedAt.FromISO8601().ToShortDateString() );
+          GUICommon.SetProperty( "#Trakt.Episode.WatchList.Notes", item.Notes );
 
-            GUICommon.SetShowProperties(item.Show);
-            GUICommon.SetEpisodeProperties(item.Show, item.Episode);
+          GUICommon.SetShowProperties( item.Show );
+          GUICommon.SetEpisodeProperties( item.Show, item.Episode );
         }
 
-        private void OnEpisodeSelected(GUIListItem item, GUIControl parent)
+        private void OnEpisodeSelected( GUIListItem item, GUIControl parent)
         {
             PreviousSelectedIndex = Facade.SelectedListItemIndex;
 

--- a/TraktPlugin/GUI/GUIWatchListMovies.cs
+++ b/TraktPlugin/GUI/GUIWatchListMovies.cs
@@ -658,14 +658,16 @@ namespace TraktPlugin.GUI
 
         private void ClearProperties()
         {
-            GUIUtils.SetProperty("#Trakt.Movie.WatchList.Inserted", string.Empty);
-            GUICommon.ClearMovieProperties();
+          GUIUtils.SetProperty( "#Trakt.Movie.WatchList.Inserted", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Movie.WatchList.Notes", string.Empty );
+          GUICommon.ClearMovieProperties();
         }
 
-        private void PublishWatchlistSkinProperties(TraktMovieWatchListItem item)
+        private void PublishWatchlistSkinProperties( TraktMovieWatchListItem item )
         {
-            GUICommon.SetProperty("#Trakt.Movie.WatchList.Inserted", item.ListedAt.FromISO8601().ToShortDateString());
-            GUICommon.SetMovieProperties(item.Movie);
+          GUICommon.SetProperty( "#Trakt.Movie.WatchList.Inserted", item.ListedAt.FromISO8601().ToShortDateString() );
+          GUICommon.SetProperty( "#Trakt.Movie.WatchList.Notes", item.Notes );
+          GUICommon.SetMovieProperties( item.Movie );
         }
 
         private void OnMovieSelected(GUIListItem item, GUIControl parent)

--- a/TraktPlugin/GUI/GUIWatchListShows.cs
+++ b/TraktPlugin/GUI/GUIWatchListShows.cs
@@ -582,14 +582,16 @@ namespace TraktPlugin.GUI
 
         private void ClearProperties()
         {
-            GUIUtils.SetProperty("#Trakt.Show.WatchList.Inserted", string.Empty);
-            GUICommon.ClearShowProperties();
+          GUIUtils.SetProperty( "#Trakt.Show.WatchList.Inserted", string.Empty );
+          GUIUtils.SetProperty( "#Trakt.Show.WatchList.Notes", string.Empty );
+          GUICommon.ClearShowProperties();
         }
 
-        private void PublishWatchlistSkinProperties(TraktShowWatchListItem item)
+        private void PublishWatchlistSkinProperties( TraktShowWatchListItem item )
         {
-            GUICommon.SetProperty("#Trakt.Show.WatchList.Inserted", item.ListedAt.FromISO8601().ToShortDateString());
-            GUICommon.SetShowProperties(item.Show);
+          GUICommon.SetProperty( "#Trakt.Show.WatchList.Inserted", item.ListedAt.FromISO8601().ToShortDateString() );
+          GUICommon.SetProperty( "#Trakt.Show.WatchList.Notes", item.Notes );
+          GUICommon.SetShowProperties( item.Show );
         }
 
         private void OnShowSelected(GUIListItem item, GUIControl parent)

--- a/TraktPlugin/TraktDashboard.cs
+++ b/TraktPlugin/TraktDashboard.cs
@@ -812,7 +812,6 @@ namespace TraktPlugin
                 GUICommon.SetProperty(string.Format("#Trakt.Show.{0}.ImdbId", i), trendingItem.Show.Ids.Imdb);
                 GUICommon.SetProperty(string.Format("#Trakt.Show.{0}.TmdbId", i), trendingItem.Show.Ids.Tmdb);
                 GUICommon.SetProperty(string.Format("#Trakt.Show.{0}.TvdbId", i), trendingItem.Show.Ids.Tvdb);
-                GUICommon.SetProperty(string.Format("#Trakt.Show.{0}.TvRageId", i), trendingItem.Show.Ids.TvRage);
                 GUICommon.SetProperty(string.Format("#Trakt.Show.{0}.Title", i), trendingItem.Show.Title);
                 GUICommon.SetProperty(string.Format("#Trakt.Show.{0}.Url", i), string.Format("http://trakt.tv/shows/{0}", trendingItem.Show.Ids.Slug));
                 GUICommon.SetProperty(string.Format("#Trakt.Show.{0}.AirDay", i), trendingItem.Show.Airs.Day);
@@ -855,7 +854,6 @@ namespace TraktPlugin
                 GUIUtils.SetProperty(string.Format("#Trakt.Show.{0}.ImdbId", i), string.Empty);
                 GUIUtils.SetProperty(string.Format("#Trakt.Show.{0}.TvdbId", i), string.Empty);
                 GUIUtils.SetProperty(string.Format("#Trakt.Show.{0}.TmdbId", i), string.Empty);
-                GUIUtils.SetProperty(string.Format("#Trakt.Show.{0}.TvRageId", i), string.Empty);
                 GUIUtils.SetProperty(string.Format("#Trakt.Show.{0}.Title", i), string.Empty);
                 GUIUtils.SetProperty(string.Format("#Trakt.Show.{0}.Url", i), string.Empty);
                 GUIUtils.SetProperty(string.Format("#Trakt.Show.{0}.AirDay", i), string.Empty);


### PR DESCRIPTION
* Updated skin properties:
```
#Trakt.Show.TotalRuntime
#Trakt.Show.SubGenres
#Trakt.Show.OriginalTitle
#Trakt.Show.Tagline

#Trakt.Season.OriginalTitle
#Trakt.Season.TotalRuntime

#Trakt.Episode.OriginalTitle
#Trakt.Episode.Released
#Trakt.Episode.EffectiveReleaseDate
#Trakt.Episode.EpisodeType
#Trakt.Episode.AfterCredits
#Trakt.Episode.DuringCredits

#Trakt.Movie.OriginalTitle
#Trakt.Movie.Country
#Trakt.Movie.SubGenres
#Trakt.Movie.AfterCredits
#Trakt.Movie.DuringCredits

#Trakt.Movie.WatchList.Notes
#Trakt.Show.WatchList.Notes
#Trakt.Episode.WatchList.Notes

#Trakt.List.Notes

```
* Set pagination max items to 250 due to future API restrictions.
* Protect against bad data from API request on movie collection endpoint