### PR TITLE
Support for community (favourited) and user Favourites GUI

### DIFF
--- a/TraktAPI/DataStructures/TraktMoviesFavorited.cs
+++ b/TraktAPI/DataStructures/TraktMoviesFavorited.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace TraktAPI.DataStructures
+{
+  public class TraktMoviesFavorited : TraktPagination
+  {
+    public IEnumerable<TraktMovieFavorited> Movies { get; set; }
+  }
+
+  [DataContract]
+  public class TraktMovieFavorited
+  {
+    [DataMember( Name = "user_count" )]
+    public int UserCount { get; set; }
+
+    [DataMember( Name = "movie" )]
+    public TraktMovieSummary Movie { get; set; }
+  }
+}

--- a/TraktAPI/DataStructures/TraktShowsFavorited.cs
+++ b/TraktAPI/DataStructures/TraktShowsFavorited.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace TraktAPI.DataStructures
+{
+  public class TraktShowsFavorited : TraktPagination
+  {
+    public IEnumerable<TraktShowFavorited> Shows { get; set; }
+  }
+
+  [DataContract]
+  public class TraktShowFavorited
+  {
+    [DataMember( Name = "user_count" )]
+    public int UserCount { get; set; }
+
+    [DataMember( Name = "show" )]
+    public TraktShowSummary Show { get; set; }
+  }
+}

--- a/TraktAPI/TraktAPI.cs
+++ b/TraktAPI/TraktAPI.cs
@@ -1099,6 +1099,38 @@ namespace TraktAPI
 
         #endregion
 
+        #region Favorited (Community)
+
+        /// <summary>
+        /// Returns the most favorited movies in the specified time period, defaulting to weekly. All stats are relative to the specific time period.
+        /// </summary>
+        /// <param name="period">Time period. Possible values:  daily , weekly , monthly , all.</param>
+        public static TraktMoviesFavorited GetFavoritedMovies( string period = "weekly", int page = 1, int maxItems = 100 )
+        {
+          var response = GetFromTrakt( string.Format( TraktURIs.FavoritedMovies, period, page, maxItems ), out WebHeaderCollection headers );
+          if ( response == null )
+            return null;
+
+          try
+          {
+            return new TraktMoviesFavorited
+            {
+              CurrentPage = page,
+              TotalItemsPerPage = maxItems,
+              TotalPages = int.Parse( headers[ "X-Pagination-Page-Count" ] ),
+              TotalItems = int.Parse( headers[ "X-Pagination-Item-Count" ] ),
+              Movies = response.FromJSONArray<TraktMovieFavorited>()
+            };
+          }
+          catch
+          {
+            // most likely bad header response
+            return null;
+          }
+        }
+
+        #endregion
+
         #region Anticipated
 
         public static TraktMoviesAnticipated GetAnticipatedMovies(int page = 1, int maxItems = 100)
@@ -1360,6 +1392,38 @@ namespace TraktAPI
                 // most likely bad header response
                 return null;
             }
+        }
+
+        #endregion
+
+        #region Favorited (Community)
+
+        /// <summary>
+        /// Returns the most favorited shows in the specified time period, defaulting to weekly. All stats are relative to the specific time period.
+        /// </summary>
+        /// <param name="period">Time period. Possible values:  daily , weekly , monthly , all.</param>
+        public static TraktShowsFavorited GetFavoritedShows( string period = "weekly", int page = 1, int maxItems = 100 )
+        {
+          var response = GetFromTrakt( string.Format( TraktURIs.FavoritedShows, period, page, maxItems ), out WebHeaderCollection headers );
+          if ( response == null )
+            return null;
+
+          try
+          {
+            return new TraktShowsFavorited
+            {
+              CurrentPage = page,
+              TotalItemsPerPage = maxItems,
+              TotalPages = int.Parse( headers[ "X-Pagination-Page-Count" ] ),
+              TotalItems = int.Parse( headers[ "X-Pagination-Item-Count" ] ),
+              Shows = response.FromJSONArray<TraktShowFavorited>()
+            };
+          }
+          catch
+          {
+            // most likely bad header response
+            return null;
+          }
         }
 
         #endregion

--- a/TraktAPI/TraktAPI.csproj
+++ b/TraktAPI/TraktAPI.csproj
@@ -56,6 +56,8 @@
     <Compile Include="DataStructures\TraktListsPopular.cs" />
     <Compile Include="DataStructures\TraktListsTrending.cs" />
     <Compile Include="DataStructures\TraktListTrending.cs" />
+    <Compile Include="DataStructures\TraktShowsFavorited.cs" />
+    <Compile Include="DataStructures\TraktMoviesFavorited.cs" />
     <Compile Include="DataStructures\TraktPlexId.cs" />
     <Compile Include="DataStructures\TraktMediaInfo.cs" />
     <Compile Include="DataStructures\TraktMovieCalendar.cs" />

--- a/TraktAPI/TraktAPI.csproj
+++ b/TraktAPI/TraktAPI.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>Externals\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\Externals\Newtonsoft.Json.dll</HintPath>
       <Aliases>nsoft</Aliases>
       <Private>False</Private>
     </Reference>

--- a/TraktAPI/TraktURIs.cs
+++ b/TraktAPI/TraktURIs.cs
@@ -76,6 +76,9 @@ namespace TraktAPI
     public const string TrendingMovies = "https://api.trakt.tv/movies/trending?extended=full&page={0}&limit={1}";
     public const string TrendingShows = "https://api.trakt.tv/shows/trending?extended=full&page={0}&limit={1}";
 
+    public const string FavoritedMovies = "https://api.trakt.tv/movies/favorited/{0}?extended=full&page={1}&limit={2}";
+    public const string FavoritedShows = "https://api.trakt.tv/shows/favorited/{0}?extended=full&page={1}&limit={2}";
+
     public const string PopularMovies = "https://api.trakt.tv/movies/popular?extended=full&page={0}&limit={1}";
     public const string PopularShows = "https://api.trakt.tv/shows/popular?extended=full&page={0}&limit={1}";
 

--- a/TraktPlugin/GUI/GUICalendarMovies.cs
+++ b/TraktPlugin/GUI/GUICalendarMovies.cs
@@ -65,6 +65,8 @@ namespace TraktPlugin.GUI
             AddMovieToList,
             AddMovieToWatchlist,
             RemoveMovieFromWatchlist,
+            AddToFavorites,
+            RemoveFromFavorites,
             Related,
             AddToLibrary,
             RemoveFromLibrary,
@@ -396,6 +398,20 @@ namespace TraktPlugin.GUI
                 listItem.ItemId = (int)ContextMenuItem.RemoveMovieFromWatchlist;
             }
 
+            // Add/Remove Movie Favorites
+            if ( !calendarItem.Movie.IsFavorited() )
+            {
+              listItem = new GUIListItem( Translation.AddToFavorites );
+              dlg.Add( listItem );
+              listItem.ItemId = (int)ContextMenuItem.AddToFavorites;
+            }
+            else
+            {
+              listItem = new GUIListItem( Translation.RemoveFromFavorites );
+              dlg.Add( listItem );
+              listItem.ItemId = (int)ContextMenuItem.RemoveFromFavorites;
+            }
+
             // Add Movie to Custom List
             listItem = new GUIListItem(Translation.AddToList);
             dlg.Add(listItem);
@@ -499,6 +515,16 @@ namespace TraktPlugin.GUI
                     OnMovieSelected(Facade.SelectedListItem, Facade);
                     GUIWatchListMovies.ClearCache(TraktSettings.Username);
                     break;
+
+                case ( (int)ContextMenuItem.AddToFavorites ):
+                  TraktHelper.AddMovieToFavorites( calendarItem.Movie, true );
+                  OnMovieSelected( Facade.SelectedListItem, Facade );
+                  break;
+
+                case ( (int)ContextMenuItem.RemoveFromFavorites ):
+                  TraktHelper.RemoveMovieFromFavorites( calendarItem.Movie, true );
+                  OnMovieSelected( Facade.SelectedListItem, Facade );
+                  break;
 
                 case ((int)ContextMenuItem.AddMovieToList):
                     TraktHelper.AddRemoveMovieInUserList(calendarItem.Movie, false);

--- a/TraktPlugin/GUI/GUICalendarTV.cs
+++ b/TraktPlugin/GUI/GUICalendarTV.cs
@@ -75,6 +75,8 @@ namespace TraktPlugin.GUI
             AddEpisodeToWatchList,
             RemoveShowFromWatchList,
             RemoveEpisodeFromWatchList,
+            AddToFavorites,
+            RemoveFromFavorites,
             Related,
             AddToLibrary,
             RemoveFromLibrary,
@@ -430,6 +432,20 @@ namespace TraktPlugin.GUI
                 listItem.ItemId = (int)ContextMenuItem.RemoveShowFromWatchList;
             }
 
+            // Add/Remove Show Favorite
+            if ( !calendarItem.Show.IsFavorited() )
+            {
+              listItem = new GUIListItem( Translation.AddToFavorites );
+              dlg.Add( listItem );
+              listItem.ItemId = (int)ContextMenuItem.AddToFavorites;
+            }
+            else
+            {
+              listItem = new GUIListItem( Translation.RemoveFromFavorites );
+              dlg.Add( listItem );
+              listItem.ItemId = (int)ContextMenuItem.RemoveFromFavorites;
+            }
+
             // Add/Remove Episode Watchlist
             if (!calendarItem.Episode.IsWatchlisted())
             {
@@ -567,6 +583,18 @@ namespace TraktPlugin.GUI
                     OnEpisodeSelected(Facade.SelectedListItem, Facade);
                     GUIWatchListShows.ClearCache(TraktSettings.Username);
                     break;
+
+                case ( (int)ContextMenuItem.AddToFavorites ):
+                  TraktHelper.AddShowToFavorites( calendarItem.Show );
+                  OnEpisodeSelected( Facade.SelectedListItem, Facade );
+                  ( Facade.SelectedListItem as GUIEpisodeListItem ).Images.NotifyPropertyChanged( "Screen" );
+                  break;
+
+                case ( (int)ContextMenuItem.RemoveFromFavorites ):
+                  TraktHelper.RemoveShowFromFavorites( calendarItem.Show );
+                  OnEpisodeSelected( Facade.SelectedListItem, Facade );
+                  ( Facade.SelectedListItem as GUIEpisodeListItem ).Images.NotifyPropertyChanged( "Screen" );
+                  break;
 
                 case ((int)ContextMenuItem.AddEpisodeToWatchList):
                     TraktHelper.AddEpisodeToWatchList(calendarItem.Episode);

--- a/TraktPlugin/GUI/GUICommon.cs
+++ b/TraktPlugin/GUI/GUICommon.cs
@@ -132,8 +132,12 @@ namespace TraktPlugin.GUI
         AnticipatedMovies = 87605,
         AnticipatedShows = 87606,
         BoxOffice = 87607,
-        CalendarMovies = 87700
-    }
+        CalendarMovies = 87700,
+        UserFavoriteMovies = 87701,
+        UserFavoriteShows = 87702,
+        FavoritedMovies = 87703,
+        FavoritedShows = 87704,
+  }
 
     enum TraktDashboardControls
     {
@@ -296,7 +300,6 @@ namespace TraktPlugin.GUI
         list,
         comment
     }
-
 
     public enum TraktListType
     {
@@ -2199,8 +2202,10 @@ namespace TraktPlugin.GUI
                 pItem.ItemId = (int)SortingFields.Anticipated;
             }
 
-            // Custom Lists
-            if (GUIWindowManager.ActiveWindow == (int)TraktGUIWindows.CustomListItems)
+            // Custom Lists / Favorites
+            if ( GUIWindowManager.ActiveWindow == (int)TraktGUIWindows.CustomListItems ||
+                 GUIWindowManager.ActiveWindow == (int)TraktGUIWindows.UserFavoriteMovies ||
+                 GUIWindowManager.ActiveWindow == (int)TraktGUIWindows.UserFavoriteShows )
             {
                 pItem = new GUIListItem(Translation.Rank);
                 dlg.Add(pItem);

--- a/TraktPlugin/GUI/GUICommon.cs
+++ b/TraktPlugin/GUI/GUICommon.cs
@@ -219,7 +219,8 @@ namespace TraktPlugin.GUI
         Popularity,
         Anticipated,
         Rank,
-        Added
+        Added,
+        UserCount
     }
 
     public enum SortingDirections
@@ -2216,6 +2217,15 @@ namespace TraktPlugin.GUI
                 pItem.ItemId = (int)SortingFields.Added;
             }
 
+            // Favorited
+            if (GUIWindowManager.ActiveWindow == (int)TraktGUIWindows.FavoritedMovies ||
+                GUIWindowManager.ActiveWindow == (int)TraktGUIWindows.FavoritedShows)
+            {
+                pItem = new GUIListItem(Translation.UserCount);
+                dlg.Add(pItem);
+                pItem.ItemId = (int)SortingFields.UserCount;
+            }
+
             // set the focus to currently used sort method
             dlg.SelectedLabel = (int)currentSortBy.Field;
 
@@ -2278,6 +2288,11 @@ namespace TraktPlugin.GUI
                     newSortBy.Field = SortingFields.Added;
                     break;
 
+                case (int)SortingFields.UserCount:
+                  newSortBy.Direction = SortingDirections.Descending;
+                  newSortBy.Field = SortingFields.UserCount;
+                  break;
+
                 default:
                     newSortBy.Field = SortingFields.Title;
                     break;
@@ -2288,7 +2303,7 @@ namespace TraktPlugin.GUI
 
         internal static string GetSortByString(SortBy currentSortBy)
         {
-            string strLine = string.Empty;
+            string strLine;
 
             switch (currentSortBy.Field)
             {
@@ -2336,12 +2351,74 @@ namespace TraktPlugin.GUI
                     strLine = Translation.Inserted;
                     break;
 
+                case SortingFields.UserCount:
+                  strLine = Translation.UserCount;
+                  break;
+
                 default:
                     strLine = Translation.Title;
                     break;
             }
 
             return string.Format(Translation.SortBy, strLine);
+        }
+
+        #endregion
+
+        #region Time Period
+
+        internal static string ShowFavoritedPeriodMenu( string currentPeriod )
+        {
+          var dlg = (GUIDialogMenu)GUIWindowManager.GetWindow( (int)GUIWindow.Window.WINDOW_DIALOG_MENU );
+          if ( dlg == null )
+            return null;
+
+          dlg.Reset();
+          dlg.SetHeading( Translation.Period );
+
+          var periods = new[] { "daily", "weekly", "monthly", "all" };
+          foreach ( var period in periods )
+          {
+            var pItem = new GUIListItem( GetPeriodString( period ) );
+            dlg.Add( pItem );
+            pItem.ItemId = Array.IndexOf(periods, period);
+          }
+
+          // set the focus to currently used period
+          dlg.SelectedLabel = Array.IndexOf(periods, currentPeriod);
+
+          // show dialog and wait for result
+          dlg.DoModal( GUIWindowManager.ActiveWindow );
+          if ( dlg.SelectedId == -1 )
+            return null;
+
+          return periods[ dlg.SelectedId ];
+        }
+
+        internal static string GetPeriodString( string period )
+        {
+          string strLine;
+
+          switch ( period )
+          {
+            case "daily":
+              strLine = Translation.PeriodDaily;
+              break;
+            case "weekly":
+              strLine = Translation.PeriodWeekly;
+              break;
+            case "monthly":
+              strLine = Translation.PeriodMonthly;
+              break;
+            case "all":
+              strLine = Translation.PeriodAll;
+              break;
+            default:
+              strLine = Translation.PeriodWeekly;
+              break;
+          }
+
+          return string.Format( Translation.CurrentPeriod, strLine );
         }
 
         #endregion
@@ -3562,6 +3639,40 @@ namespace TraktPlugin.GUI
             return showsToFilter;
         }
 
+        internal static IEnumerable<TraktMovieFavorited> FilterFavoritedMovies( IEnumerable<TraktMovieFavorited> moviesToFilter )
+        {
+          if ( TraktSettings.FavoritedMoviesHideWatched )
+            moviesToFilter = moviesToFilter.Where( t => !t.Movie.IsWatched() );
+
+          if ( TraktSettings.FavoritedMoviesHideWatchlisted )
+            moviesToFilter = moviesToFilter.Where( t => !t.Movie.IsWatchlisted() );
+
+          if ( TraktSettings.FavoritedMoviesHideCollected )
+            moviesToFilter = moviesToFilter.Where( t => !t.Movie.IsCollected() );
+
+          if ( TraktSettings.FavoritedMoviesHideRated )
+            moviesToFilter = moviesToFilter.Where( t => t.Movie.UserRating() == null );
+
+          return moviesToFilter;
+        }
+
+        internal static IEnumerable<TraktShowFavorited> FilterFavoritedShows( IEnumerable<TraktShowFavorited> showsToFilter )
+        {
+          if ( TraktSettings.FavoritedShowsHideWatched )
+            showsToFilter = showsToFilter.Where( t => !t.Show.IsWatched() );
+
+          if ( TraktSettings.FavoritedShowsHideWatchlisted )
+            showsToFilter = showsToFilter.Where( t => !t.Show.IsWatchlisted() );
+
+          if ( TraktSettings.FavoritedShowsHideCollected )
+            showsToFilter = showsToFilter.Where( t => !t.Show.IsCollected() );
+
+          if ( TraktSettings.FavoritedShowsHideRated )
+            showsToFilter = showsToFilter.Where( t => t.Show.UserRating() == null );
+
+          return showsToFilter;
+        }
+
         internal static IEnumerable<TraktListItem> FilterListItems(IEnumerable<TraktListItem> aListItemsToFilter)
         {
             if (TraktSettings.ListItemsHideWatched)
@@ -3988,9 +4099,28 @@ namespace TraktPlugin.GUI
             return false;
         }
 
-        #endregion
+    #endregion
 
         #region Translation
+        public static string GetTranslatedFavoritedPeriod( string period )
+        {
+          if ( string.IsNullOrEmpty( period ) )
+            return string.Empty;
+
+          switch ( period.ToLower().Trim() )
+          {
+            case "daily":
+              return Translation.PeriodDaily;
+            case "weekly":
+              return Translation.PeriodWeekly;
+            case "monthly":
+              return Translation.PeriodMonthly;
+            case "all":
+              return Translation.PeriodAll;
+            default:
+              return period;
+          }
+        }
 
         public static string GetTranslatedCreditJob(string job)
         {

--- a/TraktPlugin/GUI/GUIFavoriteMovies.cs
+++ b/TraktPlugin/GUI/GUIFavoriteMovies.cs
@@ -1,0 +1,703 @@
+﻿using MediaPortal.GUI.Library;
+using MediaPortal.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TraktAPI.DataStructures;
+using TraktAPI.Extensions;
+using TraktPlugin.Cache;
+using TraktPlugin.TmdbAPI.DataStructures;
+using Action = MediaPortal.GUI.Library.Action;
+
+namespace TraktPlugin.GUI
+{
+  public class GUIFavoriteMovies : GUIWindow
+  {
+    #region Skin Controls
+
+    [SkinControl( 2 )]
+    protected GUIButtonControl layoutButton = null;
+
+    [SkinControl( 8 )]
+    protected GUISortButtonControl sortButton = null;
+
+    [SkinControl( 50 )]
+    protected GUIFacadeControl Facade = null;
+
+    [SkinControlAttribute( 60 )]
+    protected GUIImage FanartBackground = null;
+
+    [SkinControlAttribute( 61 )]
+    protected GUIImage FanartBackground2 = null;
+
+    [SkinControlAttribute( 62 )]
+    protected GUIImage loadingImage = null;
+
+    #endregion
+
+    #region Enums
+
+    enum ContextMenuItem
+    {
+      RemoveFromFavorites,
+      AddToFavorites,
+      RemoveFromWatchList,
+      AddToWatchList,
+      AddToList,
+      ChangeLayout,
+      MarkAsWatched,
+      MarkAsUnWatched,
+      AddToLibrary,
+      RemoveFromLibrary,
+      Related,
+      Rate,
+      Shouts,
+      Cast,
+      Crew,
+      Trailers,
+      SearchWithMpNZB,
+      SearchTorrent
+    }
+
+    #endregion
+
+    #region Constructor
+
+    public GUIFavoriteMovies()
+    {
+      backdrop = new ImageSwapper();
+      backdrop.PropertyOne = "#Trakt.UserFavoriteMovies.Fanart.1";
+      backdrop.PropertyTwo = "#Trakt.UserFavoriteMovies.Fanart.2";
+    }
+
+    #endregion
+
+    #region Private Variables
+
+    private GUIFacadeControl.Layout CurrentLayout { get; set; }
+    static int PreviousSelectedIndex { get; set; }
+    private readonly ImageSwapper backdrop;
+    static DateTime LastRequest = new DateTime();
+    static readonly Dictionary<string, IEnumerable<TraktFavoriteItem>> userFavorites = new Dictionary<string, IEnumerable<TraktFavoriteItem>>();
+
+    static IEnumerable<TraktFavoriteItem> FavoriteMovies
+    {
+      get
+      {
+        if ( !userFavorites.Keys.Contains( CurrentUser ) || LastRequest < DateTime.UtcNow.Subtract( new TimeSpan( 0, TraktSettings.WebRequestCacheMinutes, 0 ) ) )
+        {
+          string username = CurrentUser == TraktSettings.Username ? "me" : CurrentUser;
+
+          // NB: since we're returning all items there is no need to use the sortby API parameters for each page request
+          int maxItemsPerPage = 100;
+          TraktFavoriteItems favoriteItems = TraktAPI.TraktAPI.GetFavourites( username, type: "movies", extendedInfoParams: "full", page: 1, maxItems: maxItemsPerPage );
+
+          if ( favoriteItems == null || favoriteItems.Items == null )
+          {
+            userFavorites.Remove( CurrentUser );
+            return null;
+          }
+
+          _FavoriteMovies = favoriteItems.Items;
+
+          // get next page(s) if required
+          while ( favoriteItems.CurrentPage < favoriteItems.TotalPages )
+          {
+            // Note: API returns total pages for all watchlist types not just this one (movies)
+            // so we need to check returned items against our expected max items per page
+            if ( _FavoriteMovies.Count() < ( maxItemsPerPage * favoriteItems.CurrentPage ) )
+              break;
+
+            favoriteItems = TraktAPI.TraktAPI.GetFavourites( username, type: "movies", extendedInfoParams: "full", page: favoriteItems.CurrentPage + 1, maxItems: maxItemsPerPage );
+            if ( favoriteItems == null || favoriteItems.Items == null )
+              break;
+
+            _FavoriteMovies = _FavoriteMovies.Concat( favoriteItems.Items );
+          }
+
+          if ( userFavorites.Keys.Contains( CurrentUser ) )
+            userFavorites.Remove( CurrentUser );
+
+          userFavorites.Add( CurrentUser, _FavoriteMovies );
+          LastRequest = DateTime.UtcNow;
+          PreviousSelectedIndex = 0;
+        }
+
+        return userFavorites[ CurrentUser ];
+      }
+    }
+    static IEnumerable<TraktFavoriteItem> _FavoriteMovies = null;
+
+    #endregion
+
+    #region Public Properties
+
+    public static string CurrentUser { get; set; }
+
+    #endregion
+
+    #region Base Overrides
+
+    public override int GetID
+    {
+      get
+      {
+        return (int)TraktGUIWindows.UserFavoriteMovies;
+      }
+    }
+
+    public override bool Init()
+    {
+      return Load( GUIGraphicsContext.Skin + @"\Trakt.UserFavorite.Movies.xml" );
+    }
+
+    protected override void OnPageLoad()
+    {
+      base.OnPageLoad();
+
+      // Clear GUI Properties
+      ClearProperties();
+
+      // Requires Login
+      if ( !GUICommon.CheckLogin() )
+        return;
+
+      // Init Properties
+      InitProperties();
+
+      // Load Favorite Movies
+      LoadFavoriteMovies();
+    }
+
+    protected override void OnPageDestroy( int new_windowId )
+    {
+      GUIMovieListItem.StopDownload = true;
+      PreviousSelectedIndex = Facade.SelectedListItemIndex;
+      ClearProperties();
+
+      // save current layout
+      TraktSettings.UserFavoriteMoviesDefaultLayout = (int)CurrentLayout;
+
+      base.OnPageDestroy( new_windowId );
+    }
+
+    protected override void OnClicked( int controlId, GUIControl control, Action.ActionType actionType )
+    {
+      // wait for any background action to finish
+      if ( GUIBackgroundTask.Instance.IsBusy )
+        return;
+
+      switch ( controlId )
+      {
+        // Facade
+        case ( 50 ):
+          if ( actionType == Action.ActionType.ACTION_SELECT_ITEM )
+          {
+            CheckAndPlayMovie( true );
+          }
+          break;
+
+        // Layout Button
+        case ( 2 ):
+          CurrentLayout = GUICommon.ShowLayoutMenu( CurrentLayout, PreviousSelectedIndex );
+          break;
+
+        // Sort Button
+        case ( 8 ):
+          var newSortBy = GUICommon.ShowSortMenu( TraktSettings.SortByUserFavoriteMovies );
+          if ( newSortBy != null )
+          {
+            if ( newSortBy.Field != TraktSettings.SortByUserFavoriteMovies.Field )
+            {
+              TraktSettings.SortByUserFavoriteMovies = newSortBy;
+              PreviousSelectedIndex = 0;
+              UpdateButtonState();
+              LoadFavoriteMovies();
+            }
+          }
+          break;
+
+        default:
+          break;
+      }
+      base.OnClicked( controlId, control, actionType );
+    }
+
+    public override void OnAction( Action action )
+    {
+      switch ( action.wID )
+      {
+        case Action.ActionType.ACTION_PREVIOUS_MENU:
+          // restore current user
+          CurrentUser = TraktSettings.Username;
+          base.OnAction( action );
+          break;
+        case Action.ActionType.ACTION_PLAY:
+        case Action.ActionType.ACTION_MUSIC_PLAY:
+          CheckAndPlayMovie( false );
+          break;
+        default:
+          base.OnAction( action );
+          break;
+      }
+    }
+
+    protected override void OnShowContextMenu()
+    {
+      var selectedItem = this.Facade.SelectedListItem as GUIMovieListItem;
+      if ( selectedItem == null )
+        return;
+
+      var selectedFavoriteItem = selectedItem.TVTag as TraktFavoriteItem;
+      if ( selectedFavoriteItem == null )
+        return;
+
+      var dlg = (IDialogbox)GUIWindowManager.GetWindow( (int)GUIWindow.Window.WINDOW_DIALOG_MENU );
+      if ( dlg == null )
+        return;
+
+      dlg.Reset();
+      dlg.SetHeading( GUIUtils.PluginName() );
+
+      GUIListItem listItem = null;
+
+      // only allow removal if viewing your own favorites
+      if ( CurrentUser == TraktSettings.Username )
+      {
+        listItem = new GUIListItem( Translation.RemoveFromFavorites );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.RemoveFromFavorites;
+      }
+      else if ( !selectedFavoriteItem.Movie.IsFavorited() )
+      {
+        // viewing someone else's favorites and not in yours
+        listItem = new GUIListItem( Translation.AddToFavorites );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.AddToFavorites;
+      }
+
+      // Add to Watchlist
+      if ( !selectedFavoriteItem.Movie.IsWatchlisted() )
+      {
+        listItem = new GUIListItem( Translation.AddToWatchList );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.AddToWatchList;
+      }
+      else
+      {
+        listItem = new GUIListItem( Translation.RemoveFromWatchList );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.RemoveFromWatchList;
+      }
+
+      // Add to Custom List
+      listItem = new GUIListItem( Translation.AddToList );
+      dlg.Add( listItem );
+      listItem.ItemId = (int)ContextMenuItem.AddToList;
+
+      // Mark As Watched
+      if ( !selectedFavoriteItem.Movie.IsWatched() )
+      {
+        listItem = new GUIListItem( Translation.MarkAsWatched );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.MarkAsWatched;
+      }
+
+      // Mark As UnWatched
+      if ( selectedFavoriteItem.Movie.IsWatched() )
+      {
+        listItem = new GUIListItem( Translation.MarkAsUnWatched );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.MarkAsUnWatched;
+      }
+
+      // Add to Library
+      // Don't allow if it will be removed again on next sync
+      // movie could be part of a DVD collection
+      if ( !selectedFavoriteItem.Movie.IsCollected() && !TraktSettings.KeepTraktLibraryClean )
+      {
+        listItem = new GUIListItem( Translation.AddToLibrary );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.AddToLibrary;
+      }
+
+      if ( selectedFavoriteItem.Movie.IsCollected() )
+      {
+        listItem = new GUIListItem( Translation.RemoveFromLibrary );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.RemoveFromLibrary;
+      }
+
+      // Related Movies
+      listItem = new GUIListItem( Translation.RelatedMovies );
+      dlg.Add( listItem );
+      listItem.ItemId = (int)ContextMenuItem.Related;
+
+      // Rate Movie
+      listItem = new GUIListItem( Translation.RateMovie );
+      dlg.Add( listItem );
+      listItem.ItemId = (int)ContextMenuItem.Rate;
+
+      // Shouts
+      listItem = new GUIListItem( Translation.Comments );
+      dlg.Add( listItem );
+      listItem.ItemId = (int)ContextMenuItem.Shouts;
+
+      // Cast and Crew
+      listItem = new GUIListItem( Translation.Cast );
+      dlg.Add( listItem );
+      listItem.ItemId = (int)ContextMenuItem.Cast;
+
+      listItem = new GUIListItem( Translation.Crew );
+      dlg.Add( listItem );
+      listItem.ItemId = (int)ContextMenuItem.Crew;
+
+      // Change Layout
+      listItem = new GUIListItem( Translation.ChangeLayout );
+      dlg.Add( listItem );
+      listItem.ItemId = (int)ContextMenuItem.ChangeLayout;
+
+      // Trailers
+      if ( TraktHelper.IsTrailersAvailableAndEnabled )
+      {
+        // Trailers
+        listItem = new GUIListItem( Translation.Trailers );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.Trailers;
+      }
+
+      if ( !selectedFavoriteItem.Movie.IsCollected() && TraktHelper.IsMpNZBAvailableAndEnabled )
+      {
+        // Search for movie with mpNZB
+        listItem = new GUIListItem( Translation.SearchWithMpNZB );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.SearchWithMpNZB;
+      }
+
+      if ( !selectedFavoriteItem.Movie.IsCollected() && TraktHelper.IsMyTorrentsAvailableAndEnabled )
+      {
+        // Search for movie with MyTorrents
+        listItem = new GUIListItem( Translation.SearchTorrent );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.SearchTorrent;
+      }
+
+      // Show Context Menu
+      dlg.DoModal( GUIWindowManager.ActiveWindow );
+      if ( dlg.SelectedId < 0 )
+        return;
+
+      switch ( dlg.SelectedId )
+      {
+        case ( (int)ContextMenuItem.MarkAsWatched ):
+          TraktHelper.AddMovieToWatchHistory( selectedFavoriteItem.Movie );
+          selectedItem.IsPlayed = true;
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          GUIWatchListMovies.ClearCache( TraktSettings.Username );
+          break;
+
+        case ( (int)ContextMenuItem.MarkAsUnWatched ):
+          TraktHelper.RemoveMovieFromWatchHistory( selectedFavoriteItem.Movie );
+          selectedItem.IsPlayed = false;
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          break;
+
+        case ( (int)ContextMenuItem.AddToWatchList ):
+          TraktHelper.AddMovieToWatchList( selectedFavoriteItem.Movie, true );
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          break;
+
+        case ( (int)ContextMenuItem.RemoveFromFavorites ):
+          PreviousSelectedIndex = this.Facade.SelectedListItemIndex;
+          TraktHelper.RemoveMovieFromFavorites( selectedFavoriteItem.Movie, true );
+          if ( _FavoriteMovies.Count() >= 1 )
+          {
+            // remove from list
+            var moviesToExcept = new List<TraktFavoriteItem>();
+            moviesToExcept.Add( selectedFavoriteItem );
+            _FavoriteMovies = FavoriteMovies?.Except( moviesToExcept );
+            userFavorites[ CurrentUser ] = _FavoriteMovies;
+            LoadFavoriteMovies();
+          }
+          else
+          {
+            // no more movies left
+            ClearProperties();
+            GUIControl.ClearControl( GetID, Facade.GetID );
+            _FavoriteMovies = null;
+            userFavorites.Remove( CurrentUser );
+            // notify and exit
+            GUIUtils.ShowNotifyDialog( GUIUtils.PluginName(), Translation.NoMovieFavorites );
+            GUIWindowManager.ShowPreviousWindow();
+            return;
+          }
+          break;
+
+        case ( (int)ContextMenuItem.RemoveFromWatchList ):
+          PreviousSelectedIndex = this.Facade.SelectedListItemIndex;
+          TraktHelper.RemoveMovieFromWatchList( selectedFavoriteItem.Movie, true );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          break;
+
+        case ( (int)ContextMenuItem.AddToList ):
+          TraktHelper.AddRemoveMovieInUserList( selectedFavoriteItem.Movie, false );
+          break;
+
+        case ( (int)ContextMenuItem.Trailers ):
+          GUICommon.ShowMovieTrailersMenu( selectedFavoriteItem.Movie );
+          break;
+
+        case ( (int)ContextMenuItem.AddToLibrary ):
+          TraktHelper.AddMovieToCollection( selectedFavoriteItem.Movie );
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          if ( CurrentUser != TraktSettings.Username )
+            GUIWatchListMovies.ClearCache( TraktSettings.Username );
+          break;
+
+        case ( (int)ContextMenuItem.RemoveFromLibrary ):
+          TraktHelper.RemoveMovieFromCollection( selectedFavoriteItem.Movie );
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          if ( CurrentUser != TraktSettings.Username )
+            GUIWatchListMovies.ClearCache( TraktSettings.Username );
+          break;
+
+        case ( (int)ContextMenuItem.Related ):
+          TraktHelper.ShowRelatedMovies( selectedFavoriteItem.Movie );
+          break;
+
+        case ( (int)ContextMenuItem.Rate ):
+          GUICommon.RateMovie( selectedFavoriteItem.Movie );
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          if ( CurrentUser != TraktSettings.Username )
+            GUIWatchListMovies.ClearCache( TraktSettings.Username );
+          break;
+
+        case ( (int)ContextMenuItem.Shouts ):
+          TraktHelper.ShowMovieShouts( selectedFavoriteItem.Movie );
+          break;
+
+        case ( (int)ContextMenuItem.Cast ):
+          GUICreditsMovie.Movie = selectedFavoriteItem.Movie;
+          GUICreditsMovie.Type = GUICreditsMovie.CreditType.Cast;
+          GUICreditsMovie.Fanart = TmdbCache.GetMovieBackdropFilename( selectedItem.Images.MovieImages );
+          GUIWindowManager.ActivateWindow( (int)TraktGUIWindows.CreditsMovie );
+          break;
+
+        case ( (int)ContextMenuItem.Crew ):
+          GUICreditsMovie.Movie = selectedFavoriteItem.Movie;
+          GUICreditsMovie.Type = GUICreditsMovie.CreditType.Crew;
+          GUICreditsMovie.Fanart = TmdbCache.GetMovieBackdropFilename( selectedItem.Images.MovieImages );
+          GUIWindowManager.ActivateWindow( (int)TraktGUIWindows.CreditsMovie );
+          break;
+
+        case ( (int)ContextMenuItem.ChangeLayout ):
+          CurrentLayout = GUICommon.ShowLayoutMenu( CurrentLayout, PreviousSelectedIndex );
+          break;
+
+        case ( (int)ContextMenuItem.SearchWithMpNZB ):
+          string loadingParam = string.Format( "search:{0}", selectedFavoriteItem.Movie.Title );
+          GUIWindowManager.ActivateWindow( (int)ExternalPluginWindows.MpNZB, loadingParam );
+          break;
+
+        case ( (int)ContextMenuItem.SearchTorrent ):
+          string loadPar = selectedFavoriteItem.Movie.Title;
+          GUIWindowManager.ActivateWindow( (int)ExternalPluginWindows.MyTorrents, loadPar );
+          break;
+
+        default:
+          break;
+      }
+
+      base.OnShowContextMenu();
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private void CheckAndPlayMovie( bool jumpTo )
+    {
+      var selectedItem = this.Facade.SelectedListItem;
+      if ( selectedItem == null )
+        return;
+
+      var selectedWatchlistItem = selectedItem.TVTag as TraktMovieWatchListItem;
+      GUICommon.CheckAndPlayMovie( jumpTo, selectedWatchlistItem.Movie );
+    }
+
+    private void LoadFavoriteMovies()
+    {
+      GUIUtils.SetProperty( "#Trakt.Items", string.Empty );
+
+      GUIBackgroundTask.Instance.ExecuteInBackgroundAndCallback( () =>
+      {
+        return FavoriteMovies;
+      },
+      delegate ( bool success, object result )
+      {
+        if ( success )
+        {
+          var favorites = result as IEnumerable<TraktFavoriteItem>;
+          SendFavoriteMoviesToFacade( favorites );
+        }
+      }, Translation.GettingFavorites, true );
+    }
+
+    private void SendFavoriteMoviesToFacade( IEnumerable<TraktFavoriteItem> movieFavorites )
+    {
+      // clear facade
+      GUIControl.ClearControl( GetID, Facade.GetID );
+
+      if ( movieFavorites == null )
+      {
+        GUIUtils.ShowNotifyDialog( Translation.Error, Translation.ErrorGeneral );
+        GUIWindowManager.ShowPreviousWindow();
+        return;
+      }
+
+      if ( movieFavorites.Count() == 0 )
+      {
+        GUIUtils.ShowNotifyDialog( GUIUtils.PluginName(), string.Format( Translation.NoMovieFavorites, CurrentUser ) );
+        CurrentUser = TraktSettings.Username;
+        GUIWindowManager.ShowPreviousWindow();
+        return;
+      }
+
+      // sort movies
+      var sortedList = movieFavorites.Where( m => !string.IsNullOrEmpty( m.Movie.Title ) ).ToList();
+      sortedList.Sort( new GUIListItemMovieSorter( TraktSettings.SortByUserFavoriteMovies.Field, TraktSettings.SortByUserFavoriteMovies.Direction ) );
+
+      int itemId = 0;
+      var movieImages = new List<GUITmdbImage>();
+
+      // Add each movie
+      foreach ( var favoriteItem in sortedList )
+      {
+        // add image for download
+        var images = new GUITmdbImage { MovieImages = new TmdbMovieImages { Id = favoriteItem.Movie.Ids.Tmdb } };
+        movieImages.Add( images );
+
+        var item = new GUIMovieListItem( favoriteItem.Movie.Title, (int)TraktGUIWindows.UserFavoriteMovies );
+
+        item.Label2 = favoriteItem.Movie.Year == null ? "----" : favoriteItem.Movie.Year.ToString();
+        item.TVTag = favoriteItem;
+        item.Movie = favoriteItem.Movie;
+        item.Images = images;
+        item.ItemId = Int32.MaxValue - itemId;
+        item.IsPlayed = favoriteItem.Movie.IsWatched();
+        item.IconImage = GUIImageHandler.GetDefaultPoster( false );
+        item.IconImageBig = GUIImageHandler.GetDefaultPoster();
+        item.ThumbnailImage = GUIImageHandler.GetDefaultPoster();
+        item.OnItemSelected += OnMovieSelected;
+        Utils.SetDefaultIcons( item );
+        Facade.Add( item );
+        itemId++;
+      }
+
+      // Set Facade Layout
+      Facade.CurrentLayout = CurrentLayout;
+      GUIControl.FocusControl( GetID, Facade.GetID );
+
+      if ( PreviousSelectedIndex >= movieFavorites.Count() )
+        Facade.SelectIndex( PreviousSelectedIndex - 1 );
+      else
+        Facade.SelectIndex( PreviousSelectedIndex );
+
+      // set facade properties
+      GUIUtils.SetProperty( "#itemcount", movieFavorites.Count().ToString() );
+      GUIUtils.SetProperty( "#Trakt.Items", string.Format( "{0} {1}", movieFavorites.Count().ToString(), movieFavorites.Count() > 1 ? Translation.Movies : Translation.Movie ) );
+
+      // Download movie images Async and set to facade
+      GUIMovieListItem.GetImages( movieImages );
+    }
+
+    private void InitProperties()
+    {
+      // Fanart
+      backdrop.GUIImageOne = FanartBackground;
+      backdrop.GUIImageTwo = FanartBackground2;
+      backdrop.LoadingImage = loadingImage;
+
+      // load Favorite movies for user
+      if ( string.IsNullOrEmpty( CurrentUser ) )
+        CurrentUser = TraktSettings.Username;
+      GUICommon.SetProperty( "#Trakt.FavoriteMovies.CurrentUser", CurrentUser );
+
+      // load last layout
+      CurrentLayout = (GUIFacadeControl.Layout)TraktSettings.UserFavoriteMoviesDefaultLayout;
+
+      // Update Button States
+      UpdateButtonState();
+
+      if ( sortButton != null )
+      {
+        sortButton.SortChanged += ( o, e ) =>
+        {
+          TraktSettings.SortByUserFavoriteMovies.Direction = (SortingDirections)( e.Order - 1 );
+          PreviousSelectedIndex = 0;
+          UpdateButtonState();
+          LoadFavoriteMovies();
+        };
+      }
+    }
+
+    private void UpdateButtonState()
+    {
+      // update layout button label
+      GUIControl.SetControlLabel( GetID, layoutButton.GetID, GUICommon.GetLayoutTranslation( CurrentLayout ) );
+
+      // update sortby button label
+      if ( sortButton != null )
+      {
+        sortButton.Label = GUICommon.GetSortByString( TraktSettings.SortByUserFavoriteMovies );
+        sortButton.IsAscending = ( TraktSettings.SortByUserFavoriteMovies.Direction == SortingDirections.Ascending );
+      }
+      GUIUtils.SetProperty( "#Trakt.SortBy", GUICommon.GetSortByString( TraktSettings.SortByUserFavoriteMovies ) );
+    }
+
+    private void ClearProperties()
+    {
+      GUIUtils.SetProperty( "#Trakt.Movie.Favorite.Inserted", string.Empty );
+      GUIUtils.SetProperty( "#Trakt.Movie.Favorite.Notes", string.Empty );
+      GUICommon.ClearMovieProperties();
+    }
+
+    private void PublishFavoriteSkinProperties( TraktFavoriteItem item )
+    {
+      GUICommon.SetProperty( "#Trakt.Movie.Favorite.Inserted", item.ListedAt.FromISO8601().ToShortDateString() );
+      GUICommon.SetProperty( "#Trakt.Movie.Favorite.Notes", item.Notes );
+      GUICommon.SetMovieProperties( item.Movie );
+    }
+
+    private void OnMovieSelected( GUIListItem item, GUIControl parent )
+    {
+      PreviousSelectedIndex = Facade.SelectedListItemIndex;
+
+      var favoriteItem = item.TVTag as TraktFavoriteItem;
+      PublishFavoriteSkinProperties( favoriteItem );
+
+      string fanart = TmdbCache.GetMovieBackdropFilename( ( item as GUIMovieListItem ).Images.MovieImages );
+      if ( !string.IsNullOrEmpty( fanart ) )
+      {
+        GUIImageHandler.LoadFanart( backdrop, fanart );
+      }
+    }
+    #endregion
+
+    #region Public Methods
+
+    public static void ClearCache( string username )
+    {
+      if ( userFavorites.Keys.Contains( username ) )
+        userFavorites.Remove( username );
+    }
+
+    #endregion
+  }
+}

--- a/TraktPlugin/GUI/GUIFavoritedMovies.cs
+++ b/TraktPlugin/GUI/GUIFavoritedMovies.cs
@@ -1,0 +1,695 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using MediaPortal.GUI.Library;
+using MediaPortal.Util;
+using TraktPlugin.Cache;
+using TraktPlugin.TmdbAPI.DataStructures;
+using TraktAPI.DataStructures;
+using Action = MediaPortal.GUI.Library.Action;
+
+namespace TraktPlugin.GUI
+{
+  public class GUIFavoritedMovies : GUIWindow
+  {
+    #region Skin Controls
+
+    [SkinControl( 2 )]
+    protected GUIButtonControl layoutButton = null;
+
+    [SkinControl( 8 )]
+    protected GUISortButtonControl sortButton = null;
+
+    [SkinControl( 9 )]
+    protected GUICheckButton filterWatchedButton = null;
+
+    [SkinControl( 10 )]
+    protected GUICheckButton filterWatchListedButton = null;
+
+    [SkinControl( 11 )]
+    protected GUICheckButton filterCollectedButton = null;
+
+    [SkinControl( 12 )]
+    protected GUICheckButton filterRatedButton = null;
+
+    [SkinControl( 13 )]
+    protected GUIButtonControl periodButton = null;
+
+    [SkinControl( 50 )]
+    protected GUIFacadeControl Facade = null;
+
+    [SkinControlAttribute( 60 )]
+    protected GUIImage FanartBackground = null;
+
+    [SkinControlAttribute( 61 )]
+    protected GUIImage FanartBackground2 = null;
+
+    [SkinControlAttribute( 62 )]
+    protected GUIImage loadingImage = null;
+
+    #endregion
+
+    #region Enums
+
+    #endregion
+
+    #region Constructor
+
+    public GUIFavoritedMovies()
+    {
+      backdrop = new ImageSwapper
+      {
+        PropertyOne = "#Trakt.FavoritedMovies.Fanart.1",
+        PropertyTwo = "#Trakt.FavoritedMovies.Fanart.2"
+      };
+    }
+
+    #endregion
+
+    #region Private Variables
+
+    private Dictionary<int, TraktMoviesFavorited> FavoritedMoviePages = null;
+    private GUIFacadeControl.Layout CurrentLayout { get; set; }
+    private readonly ImageSwapper backdrop;
+    DateTime LastRequest = new DateTime();
+    int PreviousSelectedIndex = 0;
+    int CurrentPage = 1;
+
+    #endregion
+
+    #region Base Overrides
+
+    public override int GetID
+    {
+      get
+      {
+        return (int)TraktGUIWindows.FavoritedMovies;
+      }
+    }
+
+    public override bool Init()
+    {
+      return Load( GUIGraphicsContext.Skin + @"\Trakt.Favorited.Movies.xml" );
+    }
+
+    protected override void OnPageLoad()
+    {
+      base.OnPageLoad();
+
+      // Clear GUI Properties
+      ClearProperties();
+
+      // Init Properties
+      InitProperties();
+
+      // Load Favorited Movies
+      LoadFavoritedMovies( CurrentPage );
+    }
+
+    protected override void OnPageDestroy( int new_windowId )
+    {
+      GUIMovieListItem.StopDownload = true;
+      PreviousSelectedIndex = Facade.SelectedListItemIndex;
+      ClearProperties();
+
+      // save current layout
+      TraktSettings.FavoritedMoviesDefaultLayout = (int)CurrentLayout;
+
+      base.OnPageDestroy( new_windowId );
+    }
+
+    protected override void OnClicked( int controlId, GUIControl control, Action.ActionType actionType )
+    {
+      // wait for any background action to finish
+      if ( GUIBackgroundTask.Instance.IsBusy )
+        return;
+
+      switch ( controlId )
+      {
+        // Facade
+        case ( 50 ):
+          if ( actionType == Action.ActionType.ACTION_SELECT_ITEM )
+          {
+            var item = Facade.SelectedListItem as GUIMovieListItem;
+            if ( item == null )
+              return;
+
+            if ( !item.IsFolder )
+            {
+              CheckAndPlayMovie( true );
+            }
+            else
+            {
+              if ( item.IsPrevPageItem )
+                CurrentPage--;
+              else
+                CurrentPage++;
+
+              if ( CurrentPage == 1 )
+                PreviousSelectedIndex = 0;
+              else
+                PreviousSelectedIndex = 1;
+
+              // load next / previous page
+              LoadFavoritedMovies( CurrentPage );
+            }
+          }
+          break;
+
+        // Layout Button
+        case ( 2 ):
+          CurrentLayout = GUICommon.ShowLayoutMenu( CurrentLayout, PreviousSelectedIndex );
+          break;
+
+        // Sort Button
+        case ( 8 ):
+          var newSortBy = GUICommon.ShowSortMenu( TraktSettings.SortByFavoritedMovies );
+          if ( newSortBy != null )
+          {
+            if ( newSortBy.Field != TraktSettings.SortByFavoritedMovies.Field )
+            {
+              TraktSettings.SortByFavoritedMovies = newSortBy;
+              PreviousSelectedIndex = CurrentPage == 1 ? 0 : 1;
+              UpdateButtonState();
+              LoadFavoritedMovies( CurrentPage );
+            }
+          }
+          break;
+
+        // Hide Watched
+        case ( 9 ):
+          PreviousSelectedIndex = CurrentPage == 1 ? 0 : 1;
+          TraktSettings.FavoritedMoviesHideWatched = !TraktSettings.FavoritedMoviesHideWatched;
+          UpdateButtonState();
+          LoadFavoritedMovies( CurrentPage );
+          break;
+
+        // Hide Watchlisted
+        case ( 10 ):
+          PreviousSelectedIndex = CurrentPage == 1 ? 0 : 1;
+          TraktSettings.FavoritedMoviesHideWatchlisted = !TraktSettings.FavoritedMoviesHideWatchlisted;
+          UpdateButtonState();
+          LoadFavoritedMovies( CurrentPage );
+          break;
+
+        // Hide Collected
+        case ( 11 ):
+          PreviousSelectedIndex = CurrentPage == 1 ? 0 : 1;
+          TraktSettings.FavoritedMoviesHideCollected = !TraktSettings.FavoritedMoviesHideCollected;
+          UpdateButtonState();
+          LoadFavoritedMovies( CurrentPage );
+          break;
+
+        // Hide Rated
+        case ( 12 ):
+          PreviousSelectedIndex = CurrentPage == 1 ? 0 : 1;
+          TraktSettings.FavoritedMoviesHideRated = !TraktSettings.FavoritedMoviesHideRated;
+          UpdateButtonState();
+          LoadFavoritedMovies( CurrentPage );
+          break;
+
+        // Time Period Button
+        case ( 13 ):
+          var newPeriod = GUICommon.ShowFavoritedPeriodMenu( TraktSettings.FavoritedMoviesPeriod );
+          if ( newPeriod != TraktSettings.FavoritedMoviesPeriod )
+          {
+            TraktSettings.FavoritedMoviesPeriod = newPeriod;
+            PreviousSelectedIndex = CurrentPage == 1 ? 0 : 1;
+            FavoritedMoviePages = null;
+            UpdateButtonState();
+            LoadFavoritedMovies( CurrentPage );
+          }
+          break;
+
+        default:
+          break;
+      }
+      base.OnClicked( controlId, control, actionType );
+    }
+
+    public override void OnAction( Action action )
+    {
+      switch ( action.wID )
+      {
+        case Action.ActionType.ACTION_PLAY:
+        case Action.ActionType.ACTION_MUSIC_PLAY:
+          CheckAndPlayMovie( false );
+          break;
+        default:
+          base.OnAction( action );
+          break;
+      }
+    }
+
+    protected override void OnShowContextMenu()
+    {
+      var selectedItem = this.Facade.SelectedListItem as GUIMovieListItem;
+      if ( selectedItem == null )
+        return;
+
+      var selectedFavoritedItem = selectedItem.TVTag as TraktMovieFavorited;
+      if ( selectedFavoritedItem == null )
+        return;
+
+      var dlg = (IDialogbox)GUIWindowManager.GetWindow( (int)GUIWindow.Window.WINDOW_DIALOG_MENU );
+      if ( dlg == null )
+        return;
+
+      dlg.Reset();
+      dlg.SetHeading( GUIUtils.PluginName() );
+
+      GUICommon.CreateMoviesContextMenu( ref dlg, selectedFavoritedItem.Movie, false );
+
+      // Show Context Menu
+      dlg.DoModal( GUIWindowManager.ActiveWindow );
+      if ( dlg.SelectedId < 0 )
+        return;
+
+      switch ( dlg.SelectedId )
+      {
+        case ( (int)MediaContextMenuItem.MarkAsWatched ):
+          TraktHelper.AddMovieToWatchHistory( selectedFavoritedItem.Movie );
+          selectedItem.IsPlayed = true;
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          if ( TraktSettings.FavoritedMoviesHideWatched )
+            LoadFavoritedMovies( CurrentPage );
+          break;
+
+        case ( (int)MediaContextMenuItem.MarkAsUnWatched ):
+          TraktHelper.RemoveMovieFromWatchHistory( selectedFavoritedItem.Movie );
+          selectedItem.IsPlayed = false;
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          break;
+
+        case ( (int)MediaContextMenuItem.AddToWatchList ):
+          TraktHelper.AddMovieToWatchList( selectedFavoritedItem.Movie, true );
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          if ( TraktSettings.FavoritedMoviesHideWatchlisted )
+            LoadFavoritedMovies( CurrentPage );
+          break;
+
+        case ( (int)MediaContextMenuItem.RemoveFromWatchList ):
+          TraktHelper.RemoveMovieFromWatchList( selectedFavoritedItem.Movie, true );
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          break;
+
+        case ( (int)MediaContextMenuItem.AddToFavorites ):
+          TraktHelper.AddMovieToFavorites( selectedFavoritedItem.Movie, true );
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          break;
+
+        case ( (int)MediaContextMenuItem.RemoveFromFavorites ):
+          TraktHelper.RemoveMovieFromFavorites( selectedFavoritedItem.Movie, true );
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          break;
+
+        case ( (int)MediaContextMenuItem.AddToList ):
+          TraktHelper.AddRemoveMovieInUserList( selectedFavoritedItem.Movie, false );
+          break;
+
+        case ( (int)MediaContextMenuItem.AddToLibrary ):
+          TraktHelper.AddMovieToCollection( selectedFavoritedItem.Movie );
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          if ( TraktSettings.FavoritedMoviesHideCollected )
+            LoadFavoritedMovies( CurrentPage );
+          break;
+
+        case ( (int)MediaContextMenuItem.RemoveFromLibrary ):
+          TraktHelper.RemoveMovieFromCollection( selectedFavoritedItem.Movie );
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          break;
+
+        case ( (int)MediaContextMenuItem.Related ):
+          TraktHelper.ShowRelatedMovies( selectedFavoritedItem.Movie );
+          break;
+
+        case ( (int)MediaContextMenuItem.Rate ):
+          GUICommon.RateMovie( selectedFavoritedItem.Movie );
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          if ( TraktSettings.FavoritedMoviesHideRated )
+            LoadFavoritedMovies( CurrentPage );
+          break;
+
+        case ( (int)MediaContextMenuItem.Filters ):
+          if ( GUICommon.ShowMovieFiltersMenu() )
+          {
+            PreviousSelectedIndex = CurrentPage == 1 ? 0 : 1;
+            UpdateButtonState();
+            LoadFavoritedMovies( CurrentPage );
+          }
+          break;
+
+        case ( (int)MediaContextMenuItem.Shouts ):
+          TraktHelper.ShowMovieShouts( selectedFavoritedItem.Movie );
+          break;
+
+        case ( (int)MediaContextMenuItem.Cast ):
+          GUICreditsMovie.Movie = selectedFavoritedItem.Movie;
+          GUICreditsMovie.Type = GUICreditsMovie.CreditType.Cast;
+          GUICreditsMovie.Fanart = TmdbCache.GetMovieBackdropFilename( selectedItem.Images.MovieImages );
+          GUIWindowManager.ActivateWindow( (int)TraktGUIWindows.CreditsMovie );
+          break;
+
+        case ( (int)MediaContextMenuItem.Crew ):
+          GUICreditsMovie.Movie = selectedFavoritedItem.Movie;
+          GUICreditsMovie.Type = GUICreditsMovie.CreditType.Crew;
+          GUICreditsMovie.Fanart = TmdbCache.GetMovieBackdropFilename( selectedItem.Images.MovieImages );
+          GUIWindowManager.ActivateWindow( (int)TraktGUIWindows.CreditsMovie );
+          break;
+
+        case ( (int)MediaContextMenuItem.Trailers ):
+          GUICommon.ShowMovieTrailersMenu( selectedFavoritedItem.Movie );
+          break;
+
+        case ( (int)MediaContextMenuItem.ChangeLayout ):
+          CurrentLayout = GUICommon.ShowLayoutMenu( CurrentLayout, PreviousSelectedIndex );
+          break;
+
+        case ( (int)MediaContextMenuItem.SearchWithMpNZB ):
+          string loadingParam = string.Format( "search:{0}", selectedFavoritedItem.Movie.Title );
+          GUIWindowManager.ActivateWindow( (int)ExternalPluginWindows.MpNZB, loadingParam );
+          break;
+
+        case ( (int)MediaContextMenuItem.SearchTorrent ):
+          string loadPar = selectedFavoritedItem.Movie.Title;
+          GUIWindowManager.ActivateWindow( (int)ExternalPluginWindows.MyTorrents, loadPar );
+          break;
+
+        default:
+          break;
+      }
+
+      base.OnShowContextMenu();
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    TraktMoviesFavorited GetFavoritedMovies( int page )
+    {
+      TraktMoviesFavorited favoritedMovies;
+
+      if ( FavoritedMoviePages == null || LastRequest < DateTime.UtcNow.Subtract( new TimeSpan( 0, TraktSettings.WebRequestCacheMinutes, 0 ) ) )
+      {
+        // get the first page
+        favoritedMovies = TraktAPI.TraktAPI.GetFavoritedMovies( period: TraktSettings.FavoritedMoviesPeriod, page: 1, maxItems: TraktSettings.MaxFavoritedMoviesRequest );
+
+        // reset to defaults
+        LastRequest = DateTime.UtcNow;
+        CurrentPage = 1;
+        PreviousSelectedIndex = 0;
+
+        // clear the cache
+        if ( FavoritedMoviePages == null )
+          FavoritedMoviePages = new Dictionary<int, TraktMoviesFavorited>();
+        else
+          FavoritedMoviePages.Clear();
+
+        // add page to cache
+        FavoritedMoviePages.Add( 1, favoritedMovies );
+      }
+      else
+      {
+        // get page from cache if it exists
+        if ( FavoritedMoviePages.TryGetValue( page, out favoritedMovies ) )
+        {
+          return favoritedMovies;
+        }
+
+        // request next page
+        favoritedMovies = TraktAPI.TraktAPI.GetFavoritedMovies( period: TraktSettings.FavoritedMoviesPeriod, page: page, maxItems: TraktSettings.MaxFavoritedMoviesRequest );
+        if ( favoritedMovies != null && favoritedMovies.Movies != null )
+        {
+          // add to cache
+          FavoritedMoviePages.Add( page, favoritedMovies );
+        }
+      }
+      return favoritedMovies;
+    }
+
+    private void CheckAndPlayMovie( bool jumpTo )
+    {
+      var selectedItem = this.Facade.SelectedListItem;
+      if ( selectedItem == null )
+        return;
+
+      var selectedFavoritedItem = selectedItem.TVTag as TraktMovieFavorited;
+      if ( selectedFavoritedItem == null )
+        return;
+
+      GUICommon.CheckAndPlayMovie( jumpTo, selectedFavoritedItem.Movie );
+    }
+
+    private void LoadFavoritedMovies( int page = 1 )
+    {
+      GUIUtils.SetProperty( "#Trakt.Items", string.Empty );
+
+      GUIBackgroundTask.Instance.ExecuteInBackgroundAndCallback( () =>
+      {
+        return GetFavoritedMovies( page );
+      },
+      delegate ( bool success, object result )
+      {
+        if ( success )
+        {
+          var movies = result as TraktMoviesFavorited;
+          SendFavoritedMoviesToFacade( movies );
+        }
+      }, Translation.GettingFavoritedMovies, true );
+    }
+
+    private void SendFavoritedMoviesToFacade( TraktMoviesFavorited favoritedItems )
+    {
+      // clear facade
+      GUIControl.ClearControl( GetID, Facade.GetID );
+
+      if ( favoritedItems == null )
+      {
+        GUIUtils.ShowNotifyDialog( Translation.Error, Translation.ErrorGeneral );
+        GUIWindowManager.ShowPreviousWindow();
+        FavoritedMoviePages = null;
+        return;
+      }
+
+      if ( favoritedItems.Movies.Count() == 0 )
+      {
+        GUIUtils.ShowNotifyDialog( GUIUtils.PluginName(), Translation.NoFavoritedMovies );
+        GUIWindowManager.ShowPreviousWindow();
+        FavoritedMoviePages = null;
+        return;
+      }
+
+      // filter movies
+      var filteredFavoritedList = GUICommon.FilterFavoritedMovies( favoritedItems.Movies ).Where( m => !string.IsNullOrEmpty( m.Movie.Title ) ).ToList();
+
+      // sort movies
+      filteredFavoritedList.Sort( new GUIListItemMovieSorter( TraktSettings.SortByFavoritedMovies.Field, TraktSettings.SortByFavoritedMovies.Direction ) );
+
+      int itemId = 0;
+      var movieImages = new List<GUITmdbImage>();
+
+      // Add Previous Page Button
+      if ( favoritedItems.CurrentPage != 1 )
+      {
+        var prevPageItem = new GUIMovieListItem( Translation.PreviousPage, (int)TraktGUIWindows.FavoritedMovies )
+        {
+          IsPrevPageItem = true,
+          IconImage = "traktPreviousPage.png",
+          IconImageBig = "traktPreviousPage.png",
+          ThumbnailImage = "traktPreviousPage.png"
+        };
+        prevPageItem.OnItemSelected += OnPreviousPageSelected;
+        prevPageItem.IsFolder = true;
+        Facade.Add( prevPageItem );
+        itemId++;
+      }
+
+      // Add each movie mark remote if not in collection            
+      foreach ( var favoritedItem in filteredFavoritedList )
+      {
+        // add image for download
+        var images = new GUITmdbImage { MovieImages = new TmdbMovieImages { Id = favoritedItem.Movie.Ids.Tmdb } };
+        movieImages.Add( images );
+
+        var item = new GUIMovieListItem( favoritedItem.Movie.Title, (int)TraktGUIWindows.FavoritedMovies )
+        {
+          Label2 = favoritedItem.Movie.Year == null ? "----" : favoritedItem.Movie.Year.ToString(),
+          TVTag = favoritedItem,
+          Movie = favoritedItem.Movie,
+          Images = images,
+          IsPlayed = favoritedItem.Movie.IsWatched(),
+          ItemId = Int32.MaxValue - itemId,
+          IconImage = GUIImageHandler.GetDefaultPoster( false ),
+          IconImageBig = GUIImageHandler.GetDefaultPoster(),
+          ThumbnailImage = GUIImageHandler.GetDefaultPoster()
+        };
+
+        item.OnItemSelected += OnMovieSelected;
+        Utils.SetDefaultIcons( item );
+        Facade.Add( item );
+        itemId++;
+      }
+
+      // Add Next Page Button
+      if ( favoritedItems.CurrentPage != favoritedItems.TotalPages )
+      {
+        var nextPageItem = new GUIMovieListItem( Translation.NextPage, (int)TraktGUIWindows.FavoritedMovies );
+        nextPageItem.IsNextPageItem = true;
+        nextPageItem.IconImage = "traktNextPage.png";
+        nextPageItem.IconImageBig = "traktNextPage.png";
+        nextPageItem.ThumbnailImage = "traktNextPage.png";
+        nextPageItem.OnItemSelected += OnNextPageSelected;
+        nextPageItem.IsFolder = true;
+        Facade.Add( nextPageItem );
+        itemId++;
+      }
+
+      // Set Facade Layout
+      Facade.CurrentLayout = CurrentLayout;
+      GUIControl.FocusControl( GetID, Facade.GetID );
+
+      Facade.SelectIndex( PreviousSelectedIndex );
+
+      // set facade properties
+      GUIUtils.SetProperty( "#itemcount", filteredFavoritedList.Count().ToString() );
+      GUIUtils.SetProperty( "#Trakt.Items", string.Format( "{0} {1}", filteredFavoritedList.Count(), filteredFavoritedList.Count() > 1 ? Translation.Movies : Translation.Movie ) );
+
+      // Page Properties
+      GUIUtils.SetProperty( "#Trakt.Facade.CurrentPage", favoritedItems.CurrentPage.ToString() );
+      GUIUtils.SetProperty( "#Trakt.Facade.TotalPages", favoritedItems.TotalPages.ToString() );
+      GUIUtils.SetProperty( "#Trakt.Facade.TotalItemsPerPage", TraktSettings.MaxFavoritedMoviesRequest.ToString() );
+
+      // Download movie images Async and set to facade
+      GUIMovieListItem.GetImages( movieImages );
+    }
+
+    private void InitProperties()
+    {
+      // Fanart
+      backdrop.GUIImageOne = FanartBackground;
+      backdrop.GUIImageTwo = FanartBackground2;
+      backdrop.LoadingImage = loadingImage;
+
+      // load last layout
+      CurrentLayout = (GUIFacadeControl.Layout)TraktSettings.FavoritedMoviesDefaultLayout;
+
+      // Update Button States
+      UpdateButtonState();
+
+      if ( sortButton != null )
+      {
+        UpdateButtonState();
+        sortButton.SortChanged += ( o, e ) =>
+        {
+          TraktSettings.SortByFavoritedMovies.Direction = (SortingDirections)( e.Order - 1 );
+          PreviousSelectedIndex = CurrentPage == 1 ? 0 : 1;
+          UpdateButtonState();
+          LoadFavoritedMovies( CurrentPage );
+        };
+      }
+    }
+
+    private void UpdateButtonState()
+    {
+      // update layout button label
+      GUIControl.SetControlLabel( GetID, layoutButton.GetID, GUICommon.GetLayoutTranslation( CurrentLayout ) );
+
+      // update sortby button label
+      if ( sortButton != null )
+      {
+        sortButton.Label = GUICommon.GetSortByString( TraktSettings.SortByFavoritedMovies );
+        sortButton.IsAscending = ( TraktSettings.SortByFavoritedMovies.Direction == SortingDirections.Ascending );
+      }
+
+      if ( periodButton != null )
+      {
+        periodButton.Label = GUICommon.GetPeriodString( TraktSettings.FavoritedMoviesPeriod );
+      }
+
+      GUIUtils.SetProperty( "#Trakt.FavoritedMovies.Period", GUICommon.GetTranslatedFavoritedPeriod( TraktSettings.FavoritedMoviesPeriod ) );
+      GUIUtils.SetProperty( "#Trakt.SortBy", GUICommon.GetSortByString( TraktSettings.SortByFavoritedMovies ) );
+
+      // update filter buttons
+      if ( filterWatchedButton != null )
+        filterWatchedButton.Selected = TraktSettings.FavoritedMoviesHideWatched;
+      if ( filterWatchListedButton != null )
+        filterWatchListedButton.Selected = TraktSettings.FavoritedMoviesHideWatchlisted;
+      if ( filterCollectedButton != null )
+        filterCollectedButton.Selected = TraktSettings.FavoritedMoviesHideCollected;
+      if ( filterRatedButton != null )
+        filterRatedButton.Selected = TraktSettings.FavoritedMoviesHideRated;
+    }
+
+    private void ClearProperties( bool moviesOnly = false )
+    {
+      if ( !moviesOnly )
+      {
+        GUIUtils.SetProperty( "#Trakt.FavoritedMovies.Period", string.Empty );
+        GUIUtils.SetProperty( "#Trakt.FavoritedMovies.CurrentPage", string.Empty );
+        GUIUtils.SetProperty( "#Trakt.FavoritedMovies.TotalPages", string.Empty );
+        GUIUtils.SetProperty( "#Trakt.Facade.IsPageItem", string.Empty );
+      }
+
+      GUIUtils.SetProperty( "#Trakt.Movie.UserCount", string.Empty );
+
+      GUICommon.ClearMovieProperties();
+    }
+
+    private void PublishMovieSkinProperties( TraktMovieFavorited favoritedItem )
+    {
+      GUICommon.SetProperty( "#Trakt.Movie.UserCount", favoritedItem.UserCount.ToString() );
+
+      GUICommon.SetMovieProperties( favoritedItem.Movie );
+    }
+
+    private void OnMovieSelected( GUIListItem item, GUIControl control )
+    {
+      GUIUtils.SetProperty( "#Trakt.Facade.IsPageItem", false.ToString() );
+
+      PreviousSelectedIndex = Facade.SelectedListItemIndex;
+
+      var favoritedItem = item.TVTag as TraktMovieFavorited;
+      if ( favoritedItem == null )
+        return;
+
+      PublishMovieSkinProperties( favoritedItem );
+      GUIImageHandler.LoadFanart( backdrop, TmdbCache.GetMovieBackdropFilename( ( item as GUIMovieListItem ).Images.MovieImages ) );
+    }
+
+    private void OnNextPageSelected( GUIListItem item, GUIControl control )
+    {
+      GUIUtils.SetProperty( "#Trakt.Facade.IsPageItem", true.ToString() );
+      GUIUtils.SetProperty( "#Trakt.Facade.PageToLoad", ( CurrentPage + 1 ).ToString() );
+
+      backdrop.Filename = string.Empty;
+      PreviousSelectedIndex = Facade.SelectedListItemIndex;
+
+      // only clear the last selected movie properties
+      ClearProperties( true );
+    }
+
+    private void OnPreviousPageSelected( GUIListItem item, GUIControl control )
+    {
+      GUIUtils.SetProperty( "#Trakt.Facade.IsPageItem", true.ToString() );
+      GUIUtils.SetProperty( "#Trakt.Facade.PageToLoad", ( CurrentPage - 1 ).ToString() );
+
+      backdrop.Filename = string.Empty;
+      PreviousSelectedIndex = Facade.SelectedListItemIndex;
+
+      // only clear the last selected movie properties
+      ClearProperties( true );
+    }
+
+    #endregion
+  }
+}

--- a/TraktPlugin/GUI/GUIFavoritedShows.cs
+++ b/TraktPlugin/GUI/GUIFavoritedShows.cs
@@ -1,0 +1,690 @@
+﻿using MediaPortal.GUI.Library;
+using MediaPortal.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TraktAPI.DataStructures;
+using TraktAPI.Extensions;
+using TraktPlugin.Cache;
+using TraktPlugin.TmdbAPI.DataStructures;
+using Action = MediaPortal.GUI.Library.Action;
+
+namespace TraktPlugin.GUI
+{
+  public class GUIFavoritedShows : GUIWindow
+  {
+    #region Skin Controls
+
+    [SkinControl( 2 )]
+    protected GUIButtonControl layoutButton = null;
+
+    [SkinControl( 8 )]
+    protected GUISortButtonControl sortButton = null;
+
+    [SkinControl( 9 )]
+    protected GUICheckButton filterWatchedButton = null;
+
+    [SkinControl( 10 )]
+    protected GUICheckButton filterWatchListedButton = null;
+
+    [SkinControl( 11 )]
+    protected GUICheckButton filterCollectedButton = null;
+
+    [SkinControl( 12 )]
+    protected GUICheckButton filterRatedButton = null;
+
+    [SkinControl( 13 )]
+    protected GUIButtonControl periodButton = null;
+
+    [SkinControl( 50 )]
+    protected GUIFacadeControl Facade = null;
+
+    [SkinControlAttribute( 60 )]
+    protected GUIImage FanartBackground = null;
+
+    [SkinControlAttribute( 61 )]
+    protected GUIImage FanartBackground2 = null;
+
+    [SkinControlAttribute( 62 )]
+    protected GUIImage loadingImage = null;
+
+    #endregion
+
+    #region Enums
+
+    #endregion
+
+    #region Constructor
+
+    public GUIFavoritedShows()
+    {
+      backdrop = new ImageSwapper
+      {
+        PropertyOne = "#Trakt.FavoritedShows.Fanart.1",
+        PropertyTwo = "#Trakt.FavoritedShows.Fanart.2"
+      };
+    }
+
+    #endregion
+
+    #region Private Variables
+
+    private Dictionary<int, TraktShowsFavorited> FavoritedShowPages = null;
+    private GUIFacadeControl.Layout CurrentLayout { get; set; }
+    private readonly ImageSwapper backdrop;
+    DateTime LastRequest = new DateTime();
+    int PreviousSelectedIndex = 0;
+    int CurrentPage = 1;
+
+    #endregion
+
+    #region Base Overrides
+
+    public override int GetID
+    {
+      get
+      {
+        return (int)TraktGUIWindows.FavoritedShows;
+      }
+    }
+
+    public override bool Init()
+    {
+      return Load( GUIGraphicsContext.Skin + @"\Trakt.Favorited.Shows.xml" );
+    }
+
+    protected override void OnPageLoad()
+    {
+      base.OnPageLoad();
+
+      // Clear GUI Properties
+      ClearProperties();
+
+      // Init Properties
+      InitProperties();
+
+      // Load Favorited Shows
+      LoadFavoritedShows( CurrentPage );
+    }
+
+    protected override void OnPageDestroy( int new_windowId )
+    {
+      GUIShowListItem.StopDownload = true;
+      PreviousSelectedIndex = Facade.SelectedListItemIndex;
+      ClearProperties();
+
+      // save current layout
+      TraktSettings.FavoritedShowsDefaultLayout = (int)CurrentLayout;
+
+      base.OnPageDestroy( new_windowId );
+    }
+
+    protected override void OnClicked( int controlId, GUIControl control, Action.ActionType actionType )
+    {
+      // wait for any background action to finish
+      if ( GUIBackgroundTask.Instance.IsBusy )
+        return;
+
+      switch ( controlId )
+      {
+        // Facade
+        case ( 50 ):
+          if ( actionType == Action.ActionType.ACTION_SELECT_ITEM )
+          {
+            var item = Facade.SelectedListItem as GUIShowListItem;
+            if ( item == null )
+              return;
+
+            if ( !item.IsFolder )
+            {
+              CheckAndPlayEpisode( true );
+            }
+            else
+            {
+              if ( item.IsPrevPageItem )
+                CurrentPage--;
+              else
+                CurrentPage++;
+
+              if ( CurrentPage == 1 )
+                PreviousSelectedIndex = 0;
+              else
+                PreviousSelectedIndex = 1;
+
+              // load next / previous page
+              LoadFavoritedShows( CurrentPage );
+            }
+          }
+          break;
+
+        // Layout Button
+        case ( 2 ):
+          CurrentLayout = GUICommon.ShowLayoutMenu( CurrentLayout, PreviousSelectedIndex );
+          break;
+
+        // Sort Button
+        case ( 8 ):
+          var newSortBy = GUICommon.ShowSortMenu( TraktSettings.SortByFavoritedShows );
+          if ( newSortBy != null )
+          {
+            if ( newSortBy.Field != TraktSettings.SortByFavoritedShows.Field )
+            {
+              TraktSettings.SortByFavoritedShows = newSortBy;
+              PreviousSelectedIndex = CurrentPage == 1 ? 0 : 1;
+              UpdateButtonState();
+              LoadFavoritedShows( CurrentPage );
+            }
+          }
+          break;
+
+        // Hide Watched
+        case ( 9 ):
+          PreviousSelectedIndex = CurrentPage == 1 ? 0 : 1;
+          TraktSettings.FavoritedShowsHideWatched = !TraktSettings.FavoritedShowsHideWatched;
+          UpdateButtonState();
+          LoadFavoritedShows( CurrentPage );
+          break;
+
+        // Hide Watchlisted
+        case ( 10 ):
+          PreviousSelectedIndex = CurrentPage == 1 ? 0 : 1;
+          TraktSettings.FavoritedShowsHideWatchlisted = !TraktSettings.FavoritedShowsHideWatchlisted;
+          UpdateButtonState();
+          LoadFavoritedShows( CurrentPage );
+          break;
+
+        // Hide Collected
+        case ( 11 ):
+          PreviousSelectedIndex = CurrentPage == 1 ? 0 : 1;
+          TraktSettings.FavoritedShowsHideCollected = !TraktSettings.FavoritedShowsHideCollected;
+          UpdateButtonState();
+          LoadFavoritedShows( CurrentPage );
+          break;
+
+        // Hide Rated
+        case ( 12 ):
+          PreviousSelectedIndex = CurrentPage == 1 ? 0 : 1;
+          TraktSettings.FavoritedShowsHideRated = !TraktSettings.FavoritedShowsHideRated;
+          UpdateButtonState();
+          LoadFavoritedShows( CurrentPage );
+          break;
+
+        // Time Period Button
+        case ( 13 ):
+          var newPeriod = GUICommon.ShowFavoritedPeriodMenu( TraktSettings.FavoritedShowsPeriod );
+          if ( newPeriod != TraktSettings.FavoritedShowsPeriod )
+          {
+            TraktSettings.FavoritedShowsPeriod = newPeriod;
+            PreviousSelectedIndex = CurrentPage == 1 ? 0 : 1;
+            FavoritedShowPages = null;
+            UpdateButtonState();
+            LoadFavoritedShows( CurrentPage );
+          }
+          break;
+
+        default:
+          break;
+      }
+      base.OnClicked( controlId, control, actionType );
+    }
+
+    public override void OnAction( Action action )
+    {
+      switch ( action.wID )
+      {
+        case Action.ActionType.ACTION_PLAY:
+        case Action.ActionType.ACTION_MUSIC_PLAY:
+          CheckAndPlayEpisode( false );
+          break;
+        default:
+          base.OnAction( action );
+          break;
+      }
+    }
+
+    protected override void OnShowContextMenu()
+    {
+      var selectedItem = this.Facade.SelectedListItem as GUIShowListItem;
+      if ( selectedItem == null )
+        return;
+
+      var selectedFavoritedItem = selectedItem.TVTag as TraktShowFavorited;
+      if ( selectedFavoritedItem == null )
+        return;
+
+      var dlg = (IDialogbox)GUIWindowManager.GetWindow( (int)GUIWindow.Window.WINDOW_DIALOG_MENU );
+      if ( dlg == null )
+        return;
+
+      dlg.Reset();
+      dlg.SetHeading( GUIUtils.PluginName() );
+
+      GUICommon.CreateShowsContextMenu( ref dlg, selectedFavoritedItem.Show, false );
+
+      // Show Context Menu
+      dlg.DoModal( GUIWindowManager.ActiveWindow );
+      if ( dlg.SelectedId < 0 )
+        return;
+
+      switch ( dlg.SelectedId )
+      {
+        case ( (int)MediaContextMenuItem.ShowSeasonInfo ):
+          GUIWindowManager.ActivateWindow( (int)TraktGUIWindows.ShowSeasons, selectedFavoritedItem.Show.ToJSON() );
+          break;
+
+        case ( (int)MediaContextMenuItem.MarkAsWatched ):
+          GUICommon.MarkShowAsWatched( selectedFavoritedItem.Show );
+          selectedItem.IsPlayed = true;
+          OnShowSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIShowListItem ).Images.NotifyPropertyChanged( "Poster" );
+          if ( TraktSettings.FavoritedShowsHideWatched )
+            LoadFavoritedShows( CurrentPage );
+          break;
+
+        case ( (int)MediaContextMenuItem.AddToWatchList ):
+          TraktHelper.AddShowToWatchList( selectedFavoritedItem.Show );
+          OnShowSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIShowListItem ).Images.NotifyPropertyChanged( "Poster" );
+          if ( TraktSettings.FavoritedShowsHideWatchlisted )
+            LoadFavoritedShows( CurrentPage );
+          break;
+
+        case ( (int)MediaContextMenuItem.RemoveFromWatchList ):
+          TraktHelper.RemoveShowFromWatchList( selectedFavoritedItem.Show );
+          OnShowSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIShowListItem ).Images.NotifyPropertyChanged( "Poster" );
+          break;
+
+        case ( (int)MediaContextMenuItem.AddToFavorites ):
+          TraktHelper.AddShowToFavorites( selectedFavoritedItem.Show );
+          OnShowSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIShowListItem ).Images.NotifyPropertyChanged( "Poster" );
+          break;
+
+        case ( (int)MediaContextMenuItem.RemoveFromFavorites ):
+          TraktHelper.RemoveShowFromFavorites( selectedFavoritedItem.Show );
+          OnShowSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIShowListItem ).Images.NotifyPropertyChanged( "Poster" );
+          break;
+
+        case ( (int)MediaContextMenuItem.AddToList ):
+          TraktHelper.AddRemoveShowInUserList( selectedFavoritedItem.Show, false );
+          break;
+
+        case ( (int)MediaContextMenuItem.AddToLibrary ):
+          GUICommon.AddShowToCollection( selectedFavoritedItem.Show );
+          OnShowSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIShowListItem ).Images.NotifyPropertyChanged( "Poster" );
+          if ( TraktSettings.FavoritedShowsHideCollected )
+            LoadFavoritedShows( CurrentPage );
+          break;
+
+        case ( (int)MediaContextMenuItem.Related ):
+          TraktHelper.ShowRelatedShows( selectedFavoritedItem.Show );
+          break;
+
+        case ( (int)MediaContextMenuItem.Rate ):
+          GUICommon.RateShow( selectedFavoritedItem.Show );
+          OnShowSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIShowListItem ).Images.NotifyPropertyChanged( "Poster" );
+          if ( TraktSettings.FavoritedShowsHideRated )
+            LoadFavoritedShows( CurrentPage );
+          break;
+
+        case ( (int)MediaContextMenuItem.Filters ):
+          if ( GUICommon.ShowTVShowFiltersMenu() )
+          {
+            PreviousSelectedIndex = CurrentPage == 1 ? 0 : 1;
+            UpdateButtonState();
+            LoadFavoritedShows( CurrentPage );
+          }
+          break;
+
+        case ( (int)MediaContextMenuItem.Shouts ):
+          TraktHelper.ShowTVShowShouts( selectedFavoritedItem.Show );
+          break;
+
+        case ( (int)MediaContextMenuItem.Cast ):
+          GUICreditsShow.Show = selectedFavoritedItem.Show;
+          GUICreditsShow.Type = GUICreditsShow.CreditType.Cast;
+          GUICreditsShow.Fanart = TmdbCache.GetShowBackdropFilename( selectedItem.Images.ShowImages );
+          GUIWindowManager.ActivateWindow( (int)TraktGUIWindows.CreditsShow );
+          break;
+
+        case ( (int)MediaContextMenuItem.Crew ):
+          GUICreditsShow.Show = selectedFavoritedItem.Show;
+          GUICreditsShow.Type = GUICreditsShow.CreditType.Crew;
+          GUICreditsShow.Fanart = TmdbCache.GetShowBackdropFilename( selectedItem.Images.ShowImages );
+          GUIWindowManager.ActivateWindow( (int)TraktGUIWindows.CreditsShow );
+          break;
+
+        case ( (int)MediaContextMenuItem.Trailers ):
+          GUICommon.ShowTVShowTrailersMenu( selectedFavoritedItem.Show );
+          break;
+
+        case ( (int)MediaContextMenuItem.ChangeLayout ):
+          CurrentLayout = GUICommon.ShowLayoutMenu( CurrentLayout, PreviousSelectedIndex );
+          break;
+
+        case ( (int)MediaContextMenuItem.SearchWithMpNZB ):
+          string loadingParam = string.Format( "search:{0}", selectedFavoritedItem.Show.Title );
+          GUIWindowManager.ActivateWindow( (int)ExternalPluginWindows.MpNZB, loadingParam );
+          break;
+
+        case ( (int)MediaContextMenuItem.SearchTorrent ):
+          string loadPar = selectedFavoritedItem.Show.Title;
+          GUIWindowManager.ActivateWindow( (int)ExternalPluginWindows.MyTorrents, loadPar );
+          break;
+
+        default:
+          break;
+      }
+
+      base.OnShowContextMenu();
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    TraktShowsFavorited GetFavoritedShows( int page )
+    {
+      TraktShowsFavorited favoritedShows;
+
+      if ( FavoritedShowPages == null || LastRequest < DateTime.UtcNow.Subtract( new TimeSpan( 0, TraktSettings.WebRequestCacheMinutes, 0 ) ) )
+      {
+        // get the first page
+        favoritedShows = TraktAPI.TraktAPI.GetFavoritedShows( period: TraktSettings.FavoritedShowsPeriod, page: 1, maxItems: TraktSettings.MaxFavoritedShowsRequest );
+
+        // reset to defaults
+        LastRequest = DateTime.UtcNow;
+        CurrentPage = 1;
+        PreviousSelectedIndex = 0;
+
+        // clear the cache
+        if ( FavoritedShowPages == null )
+          FavoritedShowPages = new Dictionary<int, TraktShowsFavorited>();
+        else
+          FavoritedShowPages.Clear();
+
+        // add page to cache
+        FavoritedShowPages.Add( 1, favoritedShows );
+      }
+      else
+      {
+        // get page from cache if it exists
+        if ( FavoritedShowPages.TryGetValue( page, out favoritedShows ) )
+        {
+          return favoritedShows;
+        }
+
+        // request next page
+        favoritedShows = TraktAPI.TraktAPI.GetFavoritedShows( period: TraktSettings.FavoritedShowsPeriod, page: page, maxItems: TraktSettings.MaxFavoritedShowsRequest );
+        if ( favoritedShows != null && favoritedShows.Shows != null )
+        {
+          // add to cache
+          FavoritedShowPages.Add( page, favoritedShows );
+        }
+      }
+
+      return favoritedShows;
+    }
+
+    private void CheckAndPlayEpisode( bool jumpTo )
+    {
+      var selectedItem = this.Facade.SelectedListItem;
+      if ( selectedItem == null )
+        return;
+
+      var selectedFavoritedItem = selectedItem.TVTag as TraktShowFavorited;
+      if ( selectedFavoritedItem == null )
+        return;
+
+      GUICommon.CheckAndPlayFirstUnwatchedEpisode( selectedFavoritedItem.Show, jumpTo );
+    }
+
+    private void LoadFavoritedShows( int page = 1 )
+    {
+      GUIUtils.SetProperty( "#Trakt.Items", string.Empty );
+
+      GUIBackgroundTask.Instance.ExecuteInBackgroundAndCallback( () =>
+      {
+        return GetFavoritedShows( page );
+      },
+      delegate ( bool success, object result )
+      {
+        if ( success )
+        {
+          var shows = result as TraktShowsFavorited;
+          SendFavoritedShowsToFacade( shows );
+        }
+      }, Translation.GettingFavoritedShows, true );
+    }
+
+    private void SendFavoritedShowsToFacade( TraktShowsFavorited favoritedItems )
+    {
+      // clear facade
+      GUIControl.ClearControl( GetID, Facade.GetID );
+
+      if ( favoritedItems == null )
+      {
+        GUIUtils.ShowNotifyDialog( Translation.Error, Translation.ErrorGeneral );
+        GUIWindowManager.ShowPreviousWindow();
+        FavoritedShowPages = null;
+        return;
+      }
+
+      if ( favoritedItems.Shows.Count() == 0 )
+      {
+        GUIUtils.ShowNotifyDialog( GUIUtils.PluginName(), Translation.NoFavoritedShows );
+        GUIWindowManager.ShowPreviousWindow();
+        FavoritedShowPages = null;
+        return;
+      }
+
+      // filter shows
+      var filteredFavoritedList = GUICommon.FilterFavoritedShows( favoritedItems.Shows ).Where( s => !string.IsNullOrEmpty( s.Show.Title ) ).ToList();
+
+      // sort shows
+      filteredFavoritedList.Sort( new GUIListItemShowSorter( TraktSettings.SortByFavoritedShows.Field, TraktSettings.SortByFavoritedShows.Direction ) );
+
+      int itemId = 0;
+      var showImages = new List<GUITmdbImage>();
+
+      // Add Previous Page Button
+      if ( favoritedItems.CurrentPage != 1 )
+      {
+        var prevPageItem = new GUIShowListItem( Translation.PreviousPage, (int)TraktGUIWindows.FavoritedShows )
+        {
+          IsPrevPageItem = true,
+          IconImage = "traktPreviousPage.png",
+          IconImageBig = "traktPreviousPage.png",
+          ThumbnailImage = "traktPreviousPage.png"
+        };
+        prevPageItem.OnItemSelected += OnPreviousPageSelected;
+        prevPageItem.IsFolder = true;
+        Facade.Add( prevPageItem );
+        itemId++;
+      }
+
+      // Add each show mark, remote if not in collection            
+      foreach ( var favoritedItem in filteredFavoritedList )
+      {
+        // add image for download
+        var images = new GUITmdbImage { ShowImages = new TmdbShowImages { Id = favoritedItem.Show.Ids.Tmdb } };
+        showImages.Add( images );
+
+        var item = new GUIShowListItem( favoritedItem.Show.Title, (int)TraktGUIWindows.FavoritedShows )
+        {
+          Label2 = favoritedItem.Show.Year == null ? "----" : favoritedItem.Show.Year.ToString(),
+          TVTag = favoritedItem,
+          Show = favoritedItem.Show,
+          Images = images,
+          IsPlayed = favoritedItem.Show.IsWatched(),
+          ItemId = Int32.MaxValue - itemId,
+          IconImage = GUIImageHandler.GetDefaultPoster( false ),
+          IconImageBig = GUIImageHandler.GetDefaultPoster(),
+          ThumbnailImage = GUIImageHandler.GetDefaultPoster()
+        };
+
+        item.OnItemSelected += OnShowSelected;
+        Utils.SetDefaultIcons( item );
+        Facade.Add( item );
+        itemId++;
+      }
+
+      // Add Next Page Button
+      if ( favoritedItems.CurrentPage != favoritedItems.TotalPages )
+      {
+        var nextPageItem = new GUIShowListItem( Translation.NextPage, (int)TraktGUIWindows.FavoritedShows )
+        {
+          IsNextPageItem = true,
+          IconImage = "traktNextPage.png",
+          IconImageBig = "traktNextPage.png",
+          ThumbnailImage = "traktNextPage.png"
+        };
+        nextPageItem.OnItemSelected += OnNextPageSelected;
+        nextPageItem.IsFolder = true;
+        Facade.Add( nextPageItem );
+        itemId++;
+      }
+
+      // Set Facade Layout
+      Facade.CurrentLayout = CurrentLayout;
+      GUIControl.FocusControl( GetID, Facade.GetID );
+
+      Facade.SelectIndex( PreviousSelectedIndex );
+
+      // set facade properties
+      GUIUtils.SetProperty( "#itemcount", filteredFavoritedList.Count().ToString() );
+      GUIUtils.SetProperty( "#Trakt.Items", string.Format( "{0} {1}", filteredFavoritedList.Count(), filteredFavoritedList.Count() > 1 ? Translation.Shows : Translation.Show ) );
+
+      // Page Properties
+      GUIUtils.SetProperty( "#Trakt.Facade.CurrentPage", favoritedItems.CurrentPage.ToString() );
+      GUIUtils.SetProperty( "#Trakt.Facade.TotalPages", favoritedItems.TotalPages.ToString() );
+      GUIUtils.SetProperty( "#Trakt.Facade.TotalItemsPerPage", TraktSettings.MaxFavoritedShowsRequest.ToString() );
+
+      // Download show images Async and set to facade
+      GUIShowListItem.GetImages( showImages );
+    }
+
+    private void InitProperties()
+    {
+      // Fanart
+      backdrop.GUIImageOne = FanartBackground;
+      backdrop.GUIImageTwo = FanartBackground2;
+      backdrop.LoadingImage = loadingImage;
+
+      // load last layout
+      CurrentLayout = (GUIFacadeControl.Layout)TraktSettings.FavoritedShowsDefaultLayout;
+
+      // Update Button States
+      UpdateButtonState();
+
+      if ( sortButton != null )
+      {
+        UpdateButtonState();
+        sortButton.SortChanged += ( o, e ) =>
+        {
+          TraktSettings.SortByFavoritedShows.Direction = (SortingDirections)( e.Order - 1 );
+          PreviousSelectedIndex = CurrentPage == 1 ? 0 : 1;
+          UpdateButtonState();
+          LoadFavoritedShows( CurrentPage );
+        };
+      }
+    }
+
+    private void UpdateButtonState()
+    {
+      // update layout button label
+      GUIControl.SetControlLabel( GetID, layoutButton.GetID, GUICommon.GetLayoutTranslation( CurrentLayout ) );
+
+      // update sortby button label
+      if ( sortButton != null )
+      {
+        sortButton.Label = GUICommon.GetSortByString( TraktSettings.SortByFavoritedShows );
+        sortButton.IsAscending = ( TraktSettings.SortByFavoritedShows.Direction == SortingDirections.Ascending );
+      }
+
+      if ( periodButton != null )
+      {
+        periodButton.Label = GUICommon.GetPeriodString( TraktSettings.FavoritedShowsPeriod );
+      }
+
+      GUIUtils.SetProperty( "#Trakt.FavoritedShows.Period", GUICommon.GetTranslatedFavoritedPeriod( TraktSettings.FavoritedShowsPeriod ) );
+      GUIUtils.SetProperty( "#Trakt.SortBy", GUICommon.GetSortByString( TraktSettings.SortByFavoritedShows ) );
+
+      // update filter buttons
+      if ( filterWatchedButton != null )
+        filterWatchedButton.Selected = TraktSettings.FavoritedShowsHideWatched;
+      if ( filterWatchListedButton != null )
+        filterWatchListedButton.Selected = TraktSettings.FavoritedShowsHideWatchlisted;
+      if ( filterCollectedButton != null )
+        filterCollectedButton.Selected = TraktSettings.FavoritedShowsHideCollected;
+      if ( filterRatedButton != null )
+        filterRatedButton.Selected = TraktSettings.FavoritedShowsHideRated;
+    }
+
+    private void ClearProperties( bool showsOnly = false )
+    {
+      if ( !showsOnly )
+      {
+        GUIUtils.SetProperty( "#Trakt.FavoritedShows.Period", string.Empty );
+        GUIUtils.SetProperty( "#Trakt.FavoritedShows.CurrentPage", string.Empty );
+        GUIUtils.SetProperty( "#Trakt.FavoritedShows.TotalPages", string.Empty );
+        GUIUtils.SetProperty( "#Trakt.Facade.IsPageItem", string.Empty );
+      }
+
+      GUIUtils.SetProperty( "#Trakt.Show.UserCount", string.Empty );
+
+      GUICommon.ClearShowProperties();
+    }
+
+    private void PublishShowSkinProperties( TraktShowFavorited favoritedItem )
+    {
+      GUICommon.SetProperty( "#Trakt.Show.UserCount", favoritedItem.UserCount.ToString() );
+
+      GUICommon.SetShowProperties( favoritedItem.Show );
+    }
+
+    private void OnShowSelected( GUIListItem item, GUIControl control )
+    {
+      GUIUtils.SetProperty( "#Trakt.Facade.IsPageItem", false.ToString() );
+
+      PreviousSelectedIndex = Facade.SelectedListItemIndex;
+
+      var favoritedItem = item.TVTag as TraktShowFavorited;
+      if ( favoritedItem == null )
+        return;
+
+      PublishShowSkinProperties( favoritedItem );
+      GUIImageHandler.LoadFanart( backdrop, TmdbCache.GetShowBackdropFilename( ( item as GUIShowListItem ).Images.ShowImages ) );
+    }
+
+    private void OnNextPageSelected( GUIListItem item, GUIControl control )
+    {
+      GUIUtils.SetProperty( "#Trakt.Facade.IsPageItem", true.ToString() );
+      GUIUtils.SetProperty( "#Trakt.Facade.PageToLoad", ( CurrentPage + 1 ).ToString() );
+
+      backdrop.Filename = string.Empty;
+      PreviousSelectedIndex = Facade.SelectedListItemIndex;
+
+      // only clear the last selected show properties
+      ClearProperties( true );
+    }
+
+    private void OnPreviousPageSelected( GUIListItem item, GUIControl control )
+    {
+      GUIUtils.SetProperty( "#Trakt.Facade.IsPageItem", true.ToString() );
+      GUIUtils.SetProperty( "#Trakt.Facade.PageToLoad", ( CurrentPage - 1 ).ToString() );
+
+      backdrop.Filename = string.Empty;
+      PreviousSelectedIndex = Facade.SelectedListItemIndex;
+
+      // only clear the last selected show properties
+      ClearProperties( true );
+    }
+
+    #endregion
+  }
+}

--- a/TraktPlugin/GUI/GUIListItemSorter.cs
+++ b/TraktPlugin/GUI/GUIListItemSorter.cs
@@ -18,8 +18,8 @@ namespace TraktPlugin.GUI
     #endregion
 
     #region Movie Sorter
-    public class GUIListItemMovieSorter : IComparer<TraktMovieTrending>, IComparer<TraktMovieSummary>, IComparer<TraktMovieWatchListItem>, IComparer<TraktPersonMovieCast>, IComparer<TraktPersonMovieJob>, IComparer<TraktMovieAnticipated>, IComparer<TraktFavoriteItem>
-    {
+    public class GUIListItemMovieSorter : IComparer<TraktMovieTrending>, IComparer<TraktMovieSummary>, IComparer<TraktMovieWatchListItem>, IComparer<TraktPersonMovieCast>, IComparer<TraktPersonMovieJob>, IComparer<TraktMovieAnticipated>, IComparer<TraktFavoriteItem>, IComparer<TraktMovieFavorited>
+  {
         private readonly SortingFields mSortField;
         private readonly SortingDirections mSortDirection;
 
@@ -134,6 +134,20 @@ namespace TraktPlugin.GUI
           return 0;
         }
 
+        public int Compare( TraktMovieFavorited movieX, TraktMovieFavorited movieY )
+        {
+          if ( mSortField == SortingFields.UserCount )
+          {
+            int rtn = movieX.UserCount.CompareTo( movieY.UserCount );
+            if ( mSortDirection == SortingDirections.Descending )
+              rtn = -rtn;
+
+            return rtn;
+          }
+
+          return Compare( movieX.Movie, movieY.Movie );
+        }
+
         public int Compare(TraktMovieAnticipated movieX, TraktMovieAnticipated movieY)
         {
             if (mSortField == SortingFields.Anticipated)
@@ -161,7 +175,7 @@ namespace TraktPlugin.GUI
     #endregion
 
     #region Show Sorter
-    public class GUIListItemShowSorter : IComparer<TraktShowTrending>, IComparer<TraktShowSummary>, IComparer<TraktShowWatchListItem>, IComparer<TraktPersonShowCast>, IComparer<TraktPersonShowJob>, IComparer<TraktShowAnticipated>, IComparer<TraktFavoriteItem>
+    public class GUIListItemShowSorter : IComparer<TraktShowTrending>, IComparer<TraktShowSummary>, IComparer<TraktShowWatchListItem>, IComparer<TraktPersonShowCast>, IComparer<TraktPersonShowJob>, IComparer<TraktShowAnticipated>, IComparer<TraktFavoriteItem>, IComparer<TraktShowFavorited>
     {
         private readonly SortingFields mSortField;
         private readonly SortingDirections mSortDirection;
@@ -242,6 +256,20 @@ namespace TraktPlugin.GUI
             }
 
             return Compare(showX.Show as TraktShowSummary, showY.Show as TraktShowSummary);
+        }
+
+        public int Compare( TraktShowFavorited showX, TraktShowFavorited showY )
+        {
+          if ( mSortField == SortingFields.UserCount )
+          {
+            int rtn = showX.UserCount.CompareTo( showY.UserCount );
+            if ( mSortDirection == SortingDirections.Descending )
+              rtn = -rtn;
+
+            return rtn;
+          }
+
+          return Compare( showX.Show as TraktShowSummary, showY.Show as TraktShowSummary );
         }
 
         public int Compare(TraktShowWatchListItem showX, TraktShowWatchListItem showY)

--- a/TraktPlugin/GUI/GUIListItemSorter.cs
+++ b/TraktPlugin/GUI/GUIListItemSorter.cs
@@ -18,7 +18,7 @@ namespace TraktPlugin.GUI
     #endregion
 
     #region Movie Sorter
-    public class GUIListItemMovieSorter : IComparer<TraktMovieTrending>, IComparer<TraktMovieSummary>, IComparer<TraktMovieWatchListItem>, IComparer<TraktPersonMovieCast>, IComparer<TraktPersonMovieJob>, IComparer<TraktMovieAnticipated>
+    public class GUIListItemMovieSorter : IComparer<TraktMovieTrending>, IComparer<TraktMovieSummary>, IComparer<TraktMovieWatchListItem>, IComparer<TraktPersonMovieCast>, IComparer<TraktPersonMovieJob>, IComparer<TraktMovieAnticipated>, IComparer<TraktFavoriteItem>
     {
         private readonly SortingFields mSortField;
         private readonly SortingDirections mSortDirection;
@@ -115,6 +115,25 @@ namespace TraktPlugin.GUI
             return Compare(movieX.Movie as TraktMovieSummary, movieY.Movie as TraktMovieSummary);
         }
 
+        public int Compare( TraktFavoriteItem itemX, TraktFavoriteItem itemY )
+        {
+          if ( mSortField == SortingFields.Added )
+          {
+            int rtn = itemX.ListedAt.FromISO8601().CompareTo( itemY.ListedAt.FromISO8601() );
+            if ( mSortDirection == SortingDirections.Descending )
+              rtn = -rtn;
+
+            return rtn;
+          }
+
+          if ( itemX.Type == "movie" && itemY.Type == "movie" )
+          {
+            return Compare( itemX.Movie as TraktMovieSummary, itemY.Movie as TraktMovieSummary );
+          }
+
+          return 0;
+        }
+
         public int Compare(TraktMovieAnticipated movieX, TraktMovieAnticipated movieY)
         {
             if (mSortField == SortingFields.Anticipated)
@@ -142,7 +161,7 @@ namespace TraktPlugin.GUI
     #endregion
 
     #region Show Sorter
-    public class GUIListItemShowSorter : IComparer<TraktShowTrending>, IComparer<TraktShowSummary>, IComparer<TraktShowWatchListItem>, IComparer<TraktPersonShowCast>, IComparer<TraktPersonShowJob>, IComparer<TraktShowAnticipated>
+    public class GUIListItemShowSorter : IComparer<TraktShowTrending>, IComparer<TraktShowSummary>, IComparer<TraktShowWatchListItem>, IComparer<TraktPersonShowCast>, IComparer<TraktPersonShowJob>, IComparer<TraktShowAnticipated>, IComparer<TraktFavoriteItem>
     {
         private readonly SortingFields mSortField;
         private readonly SortingDirections mSortDirection;
@@ -237,6 +256,25 @@ namespace TraktPlugin.GUI
             }
 
             return Compare(showX.Show as TraktShowSummary, showY.Show as TraktShowSummary);
+        }
+
+        public int Compare( TraktFavoriteItem itemX, TraktFavoriteItem itemY )
+        {
+          if ( mSortField == SortingFields.Added )
+          {
+            int rtn = itemX.ListedAt.FromISO8601().CompareTo( itemY.ListedAt.FromISO8601() );
+            if ( mSortDirection == SortingDirections.Descending )
+              rtn = -rtn;
+
+            return rtn;
+          }
+
+          if ( itemX.Type == "show" && itemY.Type == "show" )
+          {
+            return Compare( itemX.Show as TraktShowSummary, itemY.Show as TraktShowSummary );
+          }
+
+          return 0;
         }
 
         public int Compare(TraktShowAnticipated showX, TraktShowAnticipated showY)

--- a/TraktPlugin/GUI/GUIUserFavoriteMovies.cs
+++ b/TraktPlugin/GUI/GUIUserFavoriteMovies.cs
@@ -1,0 +1,703 @@
+﻿using MediaPortal.GUI.Library;
+using MediaPortal.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TraktAPI.DataStructures;
+using TraktAPI.Extensions;
+using TraktPlugin.Cache;
+using TraktPlugin.TmdbAPI.DataStructures;
+using Action = MediaPortal.GUI.Library.Action;
+
+namespace TraktPlugin.GUI
+{
+  public class GUIUserFavoriteMovies : GUIWindow
+  {
+    #region Skin Controls
+
+    [SkinControl( 2 )]
+    protected GUIButtonControl layoutButton = null;
+
+    [SkinControl( 8 )]
+    protected GUISortButtonControl sortButton = null;
+
+    [SkinControl( 50 )]
+    protected GUIFacadeControl Facade = null;
+
+    [SkinControlAttribute( 60 )]
+    protected GUIImage FanartBackground = null;
+
+    [SkinControlAttribute( 61 )]
+    protected GUIImage FanartBackground2 = null;
+
+    [SkinControlAttribute( 62 )]
+    protected GUIImage loadingImage = null;
+
+    #endregion
+
+    #region Enums
+
+    enum ContextMenuItem
+    {
+      RemoveFromFavorites,
+      AddToFavorites,
+      RemoveFromWatchList,
+      AddToWatchList,
+      AddToList,
+      ChangeLayout,
+      MarkAsWatched,
+      MarkAsUnWatched,
+      AddToLibrary,
+      RemoveFromLibrary,
+      Related,
+      Rate,
+      Shouts,
+      Cast,
+      Crew,
+      Trailers,
+      SearchWithMpNZB,
+      SearchTorrent
+    }
+
+    #endregion
+
+    #region Constructor
+
+    public GUIUserFavoriteMovies()
+    {
+      backdrop = new ImageSwapper();
+      backdrop.PropertyOne = "#Trakt.UserFavoriteMovies.Fanart.1";
+      backdrop.PropertyTwo = "#Trakt.UserFavoriteMovies.Fanart.2";
+    }
+
+    #endregion
+
+    #region Private Variables
+
+    private GUIFacadeControl.Layout CurrentLayout { get; set; }
+    static int PreviousSelectedIndex { get; set; }
+    private readonly ImageSwapper backdrop;
+    static DateTime LastRequest = new DateTime();
+    static readonly Dictionary<string, IEnumerable<TraktFavoriteItem>> userFavorites = new Dictionary<string, IEnumerable<TraktFavoriteItem>>();
+
+    static IEnumerable<TraktFavoriteItem> FavoriteMovies
+    {
+      get
+      {
+        if ( !userFavorites.Keys.Contains( CurrentUser ) || LastRequest < DateTime.UtcNow.Subtract( new TimeSpan( 0, TraktSettings.WebRequestCacheMinutes, 0 ) ) )
+        {
+          string username = CurrentUser == TraktSettings.Username ? "me" : CurrentUser;
+
+          // NB: since we're returning all items there is no need to use the sortby API parameters for each page request
+          int maxItemsPerPage = 100;
+          TraktFavoriteItems favoriteItems = TraktAPI.TraktAPI.GetFavourites( username, type: "movies", extendedInfoParams: "full", page: 1, maxItems: maxItemsPerPage );
+
+          if ( favoriteItems == null || favoriteItems.Items == null )
+          {
+            userFavorites.Remove( CurrentUser );
+            return null;
+          }
+
+          _FavoriteMovies = favoriteItems.Items;
+
+          // get next page(s) if required
+          while ( favoriteItems.CurrentPage < favoriteItems.TotalPages )
+          {
+            // Note: API returns total pages for all watchlist types not just this one (movies)
+            // so we need to check returned items against our expected max items per page
+            if ( _FavoriteMovies.Count() < ( maxItemsPerPage * favoriteItems.CurrentPage ) )
+              break;
+
+            favoriteItems = TraktAPI.TraktAPI.GetFavourites( username, type: "movies", extendedInfoParams: "full", page: favoriteItems.CurrentPage + 1, maxItems: maxItemsPerPage );
+            if ( favoriteItems == null || favoriteItems.Items == null )
+              break;
+
+            _FavoriteMovies = _FavoriteMovies.Concat( favoriteItems.Items );
+          }
+
+          if ( userFavorites.Keys.Contains( CurrentUser ) )
+            userFavorites.Remove( CurrentUser );
+
+          userFavorites.Add( CurrentUser, _FavoriteMovies );
+          LastRequest = DateTime.UtcNow;
+          PreviousSelectedIndex = 0;
+        }
+
+        return userFavorites[ CurrentUser ];
+      }
+    }
+    static IEnumerable<TraktFavoriteItem> _FavoriteMovies = null;
+
+    #endregion
+
+    #region Public Properties
+
+    public static string CurrentUser { get; set; }
+
+    #endregion
+
+    #region Base Overrides
+
+    public override int GetID
+    {
+      get
+      {
+        return (int)TraktGUIWindows.UserFavoriteMovies;
+      }
+    }
+
+    public override bool Init()
+    {
+      return Load( GUIGraphicsContext.Skin + @"\Trakt.UserFavorite.Movies.xml" );
+    }
+
+    protected override void OnPageLoad()
+    {
+      base.OnPageLoad();
+
+      // Clear GUI Properties
+      ClearProperties();
+
+      // Requires Login
+      if ( !GUICommon.CheckLogin() )
+        return;
+
+      // Init Properties
+      InitProperties();
+
+      // Load Favorite Movies
+      LoadFavoriteMovies();
+    }
+
+    protected override void OnPageDestroy( int new_windowId )
+    {
+      GUIMovieListItem.StopDownload = true;
+      PreviousSelectedIndex = Facade.SelectedListItemIndex;
+      ClearProperties();
+
+      // save current layout
+      TraktSettings.UserFavoriteMoviesDefaultLayout = (int)CurrentLayout;
+
+      base.OnPageDestroy( new_windowId );
+    }
+
+    protected override void OnClicked( int controlId, GUIControl control, Action.ActionType actionType )
+    {
+      // wait for any background action to finish
+      if ( GUIBackgroundTask.Instance.IsBusy )
+        return;
+
+      switch ( controlId )
+      {
+        // Facade
+        case ( 50 ):
+          if ( actionType == Action.ActionType.ACTION_SELECT_ITEM )
+          {
+            CheckAndPlayMovie( true );
+          }
+          break;
+
+        // Layout Button
+        case ( 2 ):
+          CurrentLayout = GUICommon.ShowLayoutMenu( CurrentLayout, PreviousSelectedIndex );
+          break;
+
+        // Sort Button
+        case ( 8 ):
+          var newSortBy = GUICommon.ShowSortMenu( TraktSettings.SortByUserFavoriteMovies );
+          if ( newSortBy != null )
+          {
+            if ( newSortBy.Field != TraktSettings.SortByUserFavoriteMovies.Field )
+            {
+              TraktSettings.SortByUserFavoriteMovies = newSortBy;
+              PreviousSelectedIndex = 0;
+              UpdateButtonState();
+              LoadFavoriteMovies();
+            }
+          }
+          break;
+
+        default:
+          break;
+      }
+      base.OnClicked( controlId, control, actionType );
+    }
+
+    public override void OnAction( Action action )
+    {
+      switch ( action.wID )
+      {
+        case Action.ActionType.ACTION_PREVIOUS_MENU:
+          // restore current user
+          CurrentUser = TraktSettings.Username;
+          base.OnAction( action );
+          break;
+        case Action.ActionType.ACTION_PLAY:
+        case Action.ActionType.ACTION_MUSIC_PLAY:
+          CheckAndPlayMovie( false );
+          break;
+        default:
+          base.OnAction( action );
+          break;
+      }
+    }
+
+    protected override void OnShowContextMenu()
+    {
+      var selectedItem = this.Facade.SelectedListItem as GUIMovieListItem;
+      if ( selectedItem == null )
+        return;
+
+      var selectedFavoriteItem = selectedItem.TVTag as TraktFavoriteItem;
+      if ( selectedFavoriteItem == null )
+        return;
+
+      var dlg = (IDialogbox)GUIWindowManager.GetWindow( (int)GUIWindow.Window.WINDOW_DIALOG_MENU );
+      if ( dlg == null )
+        return;
+
+      dlg.Reset();
+      dlg.SetHeading( GUIUtils.PluginName() );
+
+      GUIListItem listItem = null;
+
+      // only allow removal if viewing your own favorites
+      if ( CurrentUser == TraktSettings.Username )
+      {
+        listItem = new GUIListItem( Translation.RemoveFromFavorites );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.RemoveFromFavorites;
+      }
+      else if ( !selectedFavoriteItem.Movie.IsFavorited() )
+      {
+        // viewing someone else's favorites and not in yours
+        listItem = new GUIListItem( Translation.AddToFavorites );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.AddToFavorites;
+      }
+
+      // Add to Watchlist
+      if ( !selectedFavoriteItem.Movie.IsWatchlisted() )
+      {
+        listItem = new GUIListItem( Translation.AddToWatchList );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.AddToWatchList;
+      }
+      else
+      {
+        listItem = new GUIListItem( Translation.RemoveFromWatchList );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.RemoveFromWatchList;
+      }
+
+      // Add to Custom List
+      listItem = new GUIListItem( Translation.AddToList );
+      dlg.Add( listItem );
+      listItem.ItemId = (int)ContextMenuItem.AddToList;
+
+      // Mark As Watched
+      if ( !selectedFavoriteItem.Movie.IsWatched() )
+      {
+        listItem = new GUIListItem( Translation.MarkAsWatched );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.MarkAsWatched;
+      }
+
+      // Mark As UnWatched
+      if ( selectedFavoriteItem.Movie.IsWatched() )
+      {
+        listItem = new GUIListItem( Translation.MarkAsUnWatched );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.MarkAsUnWatched;
+      }
+
+      // Add to Library
+      // Don't allow if it will be removed again on next sync
+      // movie could be part of a DVD collection
+      if ( !selectedFavoriteItem.Movie.IsCollected() && !TraktSettings.KeepTraktLibraryClean )
+      {
+        listItem = new GUIListItem( Translation.AddToLibrary );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.AddToLibrary;
+      }
+
+      if ( selectedFavoriteItem.Movie.IsCollected() )
+      {
+        listItem = new GUIListItem( Translation.RemoveFromLibrary );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.RemoveFromLibrary;
+      }
+
+      // Related Movies
+      listItem = new GUIListItem( Translation.RelatedMovies );
+      dlg.Add( listItem );
+      listItem.ItemId = (int)ContextMenuItem.Related;
+
+      // Rate Movie
+      listItem = new GUIListItem( Translation.RateMovie );
+      dlg.Add( listItem );
+      listItem.ItemId = (int)ContextMenuItem.Rate;
+
+      // Shouts
+      listItem = new GUIListItem( Translation.Comments );
+      dlg.Add( listItem );
+      listItem.ItemId = (int)ContextMenuItem.Shouts;
+
+      // Cast and Crew
+      listItem = new GUIListItem( Translation.Cast );
+      dlg.Add( listItem );
+      listItem.ItemId = (int)ContextMenuItem.Cast;
+
+      listItem = new GUIListItem( Translation.Crew );
+      dlg.Add( listItem );
+      listItem.ItemId = (int)ContextMenuItem.Crew;
+
+      // Change Layout
+      listItem = new GUIListItem( Translation.ChangeLayout );
+      dlg.Add( listItem );
+      listItem.ItemId = (int)ContextMenuItem.ChangeLayout;
+
+      // Trailers
+      if ( TraktHelper.IsTrailersAvailableAndEnabled )
+      {
+        // Trailers
+        listItem = new GUIListItem( Translation.Trailers );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.Trailers;
+      }
+
+      if ( !selectedFavoriteItem.Movie.IsCollected() && TraktHelper.IsMpNZBAvailableAndEnabled )
+      {
+        // Search for movie with mpNZB
+        listItem = new GUIListItem( Translation.SearchWithMpNZB );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.SearchWithMpNZB;
+      }
+
+      if ( !selectedFavoriteItem.Movie.IsCollected() && TraktHelper.IsMyTorrentsAvailableAndEnabled )
+      {
+        // Search for movie with MyTorrents
+        listItem = new GUIListItem( Translation.SearchTorrent );
+        dlg.Add( listItem );
+        listItem.ItemId = (int)ContextMenuItem.SearchTorrent;
+      }
+
+      // Show Context Menu
+      dlg.DoModal( GUIWindowManager.ActiveWindow );
+      if ( dlg.SelectedId < 0 )
+        return;
+
+      switch ( dlg.SelectedId )
+      {
+        case ( (int)ContextMenuItem.MarkAsWatched ):
+          TraktHelper.AddMovieToWatchHistory( selectedFavoriteItem.Movie );
+          selectedItem.IsPlayed = true;
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          GUIWatchListMovies.ClearCache( TraktSettings.Username );
+          break;
+
+        case ( (int)ContextMenuItem.MarkAsUnWatched ):
+          TraktHelper.RemoveMovieFromWatchHistory( selectedFavoriteItem.Movie );
+          selectedItem.IsPlayed = false;
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          break;
+
+        case ( (int)ContextMenuItem.AddToWatchList ):
+          TraktHelper.AddMovieToWatchList( selectedFavoriteItem.Movie, true );
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          break;
+
+        case ( (int)ContextMenuItem.RemoveFromFavorites ):
+          PreviousSelectedIndex = this.Facade.SelectedListItemIndex;
+          TraktHelper.RemoveMovieFromFavorites( selectedFavoriteItem.Movie, true );
+          if ( _FavoriteMovies.Count() >= 1 )
+          {
+            // remove from list
+            var moviesToExcept = new List<TraktFavoriteItem>();
+            moviesToExcept.Add( selectedFavoriteItem );
+            _FavoriteMovies = FavoriteMovies?.Except( moviesToExcept );
+            userFavorites[ CurrentUser ] = _FavoriteMovies;
+            LoadFavoriteMovies();
+          }
+          else
+          {
+            // no more movies left
+            ClearProperties();
+            GUIControl.ClearControl( GetID, Facade.GetID );
+            _FavoriteMovies = null;
+            userFavorites.Remove( CurrentUser );
+            // notify and exit
+            GUIUtils.ShowNotifyDialog( GUIUtils.PluginName(), Translation.NoMovieFavorites );
+            GUIWindowManager.ShowPreviousWindow();
+            return;
+          }
+          break;
+
+        case ( (int)ContextMenuItem.RemoveFromWatchList ):
+          PreviousSelectedIndex = this.Facade.SelectedListItemIndex;
+          TraktHelper.RemoveMovieFromWatchList( selectedFavoriteItem.Movie, true );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          break;
+
+        case ( (int)ContextMenuItem.AddToList ):
+          TraktHelper.AddRemoveMovieInUserList( selectedFavoriteItem.Movie, false );
+          break;
+
+        case ( (int)ContextMenuItem.Trailers ):
+          GUICommon.ShowMovieTrailersMenu( selectedFavoriteItem.Movie );
+          break;
+
+        case ( (int)ContextMenuItem.AddToLibrary ):
+          TraktHelper.AddMovieToCollection( selectedFavoriteItem.Movie );
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          if ( CurrentUser != TraktSettings.Username )
+            GUIWatchListMovies.ClearCache( TraktSettings.Username );
+          break;
+
+        case ( (int)ContextMenuItem.RemoveFromLibrary ):
+          TraktHelper.RemoveMovieFromCollection( selectedFavoriteItem.Movie );
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          if ( CurrentUser != TraktSettings.Username )
+            GUIWatchListMovies.ClearCache( TraktSettings.Username );
+          break;
+
+        case ( (int)ContextMenuItem.Related ):
+          TraktHelper.ShowRelatedMovies( selectedFavoriteItem.Movie );
+          break;
+
+        case ( (int)ContextMenuItem.Rate ):
+          GUICommon.RateMovie( selectedFavoriteItem.Movie );
+          OnMovieSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          if ( CurrentUser != TraktSettings.Username )
+            GUIWatchListMovies.ClearCache( TraktSettings.Username );
+          break;
+
+        case ( (int)ContextMenuItem.Shouts ):
+          TraktHelper.ShowMovieShouts( selectedFavoriteItem.Movie );
+          break;
+
+        case ( (int)ContextMenuItem.Cast ):
+          GUICreditsMovie.Movie = selectedFavoriteItem.Movie;
+          GUICreditsMovie.Type = GUICreditsMovie.CreditType.Cast;
+          GUICreditsMovie.Fanart = TmdbCache.GetMovieBackdropFilename( selectedItem.Images.MovieImages );
+          GUIWindowManager.ActivateWindow( (int)TraktGUIWindows.CreditsMovie );
+          break;
+
+        case ( (int)ContextMenuItem.Crew ):
+          GUICreditsMovie.Movie = selectedFavoriteItem.Movie;
+          GUICreditsMovie.Type = GUICreditsMovie.CreditType.Crew;
+          GUICreditsMovie.Fanart = TmdbCache.GetMovieBackdropFilename( selectedItem.Images.MovieImages );
+          GUIWindowManager.ActivateWindow( (int)TraktGUIWindows.CreditsMovie );
+          break;
+
+        case ( (int)ContextMenuItem.ChangeLayout ):
+          CurrentLayout = GUICommon.ShowLayoutMenu( CurrentLayout, PreviousSelectedIndex );
+          break;
+
+        case ( (int)ContextMenuItem.SearchWithMpNZB ):
+          string loadingParam = string.Format( "search:{0}", selectedFavoriteItem.Movie.Title );
+          GUIWindowManager.ActivateWindow( (int)ExternalPluginWindows.MpNZB, loadingParam );
+          break;
+
+        case ( (int)ContextMenuItem.SearchTorrent ):
+          string loadPar = selectedFavoriteItem.Movie.Title;
+          GUIWindowManager.ActivateWindow( (int)ExternalPluginWindows.MyTorrents, loadPar );
+          break;
+
+        default:
+          break;
+      }
+
+      base.OnShowContextMenu();
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private void CheckAndPlayMovie( bool jumpTo )
+    {
+      var selectedItem = this.Facade.SelectedListItem as GUIMovieListItem;
+      if ( selectedItem == null )
+        return;
+
+      var selectedMovie = selectedItem.Movie as TraktMovieSummary;
+      GUICommon.CheckAndPlayMovie( jumpTo, selectedMovie );
+    }
+
+    private void LoadFavoriteMovies()
+    {
+      GUIUtils.SetProperty( "#Trakt.Items", string.Empty );
+
+      GUIBackgroundTask.Instance.ExecuteInBackgroundAndCallback( () =>
+      {
+        return FavoriteMovies;
+      },
+      delegate ( bool success, object result )
+      {
+        if ( success )
+        {
+          var favorites = result as IEnumerable<TraktFavoriteItem>;
+          SendFavoriteMoviesToFacade( favorites );
+        }
+      }, Translation.GettingFavorites, true );
+    }
+
+    private void SendFavoriteMoviesToFacade( IEnumerable<TraktFavoriteItem> movieFavorites )
+    {
+      // clear facade
+      GUIControl.ClearControl( GetID, Facade.GetID );
+
+      if ( movieFavorites == null )
+      {
+        GUIUtils.ShowNotifyDialog( Translation.Error, Translation.ErrorGeneral );
+        GUIWindowManager.ShowPreviousWindow();
+        return;
+      }
+
+      if ( movieFavorites.Count() == 0 )
+      {
+        GUIUtils.ShowNotifyDialog( GUIUtils.PluginName(), string.Format( Translation.NoMovieFavorites, CurrentUser ) );
+        CurrentUser = TraktSettings.Username;
+        GUIWindowManager.ShowPreviousWindow();
+        return;
+      }
+
+      // sort movies
+      var sortedList = movieFavorites.Where( m => !string.IsNullOrEmpty( m.Movie.Title ) ).ToList();
+      sortedList.Sort( new GUIListItemMovieSorter( TraktSettings.SortByUserFavoriteMovies.Field, TraktSettings.SortByUserFavoriteMovies.Direction ) );
+
+      int itemId = 0;
+      var movieImages = new List<GUITmdbImage>();
+
+      // Add each movie
+      foreach ( var favoriteItem in sortedList )
+      {
+        // add image for download
+        var images = new GUITmdbImage { MovieImages = new TmdbMovieImages { Id = favoriteItem.Movie.Ids.Tmdb } };
+        movieImages.Add( images );
+
+        var item = new GUIMovieListItem( favoriteItem.Movie.Title, (int)TraktGUIWindows.UserFavoriteMovies );
+
+        item.Label2 = favoriteItem.Movie.Year == null ? "----" : favoriteItem.Movie.Year.ToString();
+        item.TVTag = favoriteItem;
+        item.Movie = favoriteItem.Movie;
+        item.Images = images;
+        item.ItemId = Int32.MaxValue - itemId;
+        item.IsPlayed = favoriteItem.Movie.IsWatched();
+        item.IconImage = GUIImageHandler.GetDefaultPoster( false );
+        item.IconImageBig = GUIImageHandler.GetDefaultPoster();
+        item.ThumbnailImage = GUIImageHandler.GetDefaultPoster();
+        item.OnItemSelected += OnMovieSelected;
+        Utils.SetDefaultIcons( item );
+        Facade.Add( item );
+        itemId++;
+      }
+
+      // Set Facade Layout
+      Facade.CurrentLayout = CurrentLayout;
+      GUIControl.FocusControl( GetID, Facade.GetID );
+
+      if ( PreviousSelectedIndex >= movieFavorites.Count() )
+        Facade.SelectIndex( PreviousSelectedIndex - 1 );
+      else
+        Facade.SelectIndex( PreviousSelectedIndex );
+
+      // set facade properties
+      GUIUtils.SetProperty( "#itemcount", movieFavorites.Count().ToString() );
+      GUIUtils.SetProperty( "#Trakt.Items", string.Format( "{0} {1}", movieFavorites.Count().ToString(), movieFavorites.Count() > 1 ? Translation.Movies : Translation.Movie ) );
+
+      // Download movie images Async and set to facade
+      GUIMovieListItem.GetImages( movieImages );
+    }
+
+    private void InitProperties()
+    {
+      // Fanart
+      backdrop.GUIImageOne = FanartBackground;
+      backdrop.GUIImageTwo = FanartBackground2;
+      backdrop.LoadingImage = loadingImage;
+
+      // load Favorite movies for user
+      if ( string.IsNullOrEmpty( CurrentUser ) )
+        CurrentUser = TraktSettings.Username;
+      GUICommon.SetProperty( "#Trakt.FavoriteMovies.CurrentUser", CurrentUser );
+
+      // load last layout
+      CurrentLayout = (GUIFacadeControl.Layout)TraktSettings.UserFavoriteMoviesDefaultLayout;
+
+      // Update Button States
+      UpdateButtonState();
+
+      if ( sortButton != null )
+      {
+        sortButton.SortChanged += ( o, e ) =>
+        {
+          TraktSettings.SortByUserFavoriteMovies.Direction = (SortingDirections)( e.Order - 1 );
+          PreviousSelectedIndex = 0;
+          UpdateButtonState();
+          LoadFavoriteMovies();
+        };
+      }
+    }
+
+    private void UpdateButtonState()
+    {
+      // update layout button label
+      GUIControl.SetControlLabel( GetID, layoutButton.GetID, GUICommon.GetLayoutTranslation( CurrentLayout ) );
+
+      // update sortby button label
+      if ( sortButton != null )
+      {
+        sortButton.Label = GUICommon.GetSortByString( TraktSettings.SortByUserFavoriteMovies );
+        sortButton.IsAscending = ( TraktSettings.SortByUserFavoriteMovies.Direction == SortingDirections.Ascending );
+      }
+      GUIUtils.SetProperty( "#Trakt.SortBy", GUICommon.GetSortByString( TraktSettings.SortByUserFavoriteMovies ) );
+    }
+
+    private void ClearProperties()
+    {
+      GUIUtils.SetProperty( "#Trakt.Movie.Favorite.Inserted", string.Empty );
+      GUIUtils.SetProperty( "#Trakt.Movie.Favorite.Notes", string.Empty );
+      GUICommon.ClearMovieProperties();
+    }
+
+    private void PublishFavoriteSkinProperties( TraktFavoriteItem item )
+    {
+      GUICommon.SetProperty( "#Trakt.Movie.Favorite.Inserted", item.ListedAt.FromISO8601().ToShortDateString() );
+      GUICommon.SetProperty( "#Trakt.Movie.Favorite.Notes", item.Notes );
+      GUICommon.SetMovieProperties( item.Movie );
+    }
+
+    private void OnMovieSelected( GUIListItem item, GUIControl parent )
+    {
+      PreviousSelectedIndex = Facade.SelectedListItemIndex;
+
+      var favoriteItem = item.TVTag as TraktFavoriteItem;
+      PublishFavoriteSkinProperties( favoriteItem );
+
+      string fanart = TmdbCache.GetMovieBackdropFilename( ( item as GUIMovieListItem ).Images.MovieImages );
+      if ( !string.IsNullOrEmpty( fanart ) )
+      {
+        GUIImageHandler.LoadFanart( backdrop, fanart );
+      }
+    }
+    #endregion
+
+    #region Public Methods
+
+    public static void ClearCache( string username )
+    {
+      if ( userFavorites.Keys.Contains( username ) )
+        userFavorites.Remove( username );
+    }
+
+    #endregion
+  }
+}

--- a/TraktPlugin/GUI/GUIUserFavoriteShows.cs
+++ b/TraktPlugin/GUI/GUIUserFavoriteShows.cs
@@ -11,7 +11,7 @@ using Action = MediaPortal.GUI.Library.Action;
 
 namespace TraktPlugin.GUI
 {
-  public class GUIFavoriteMovies : GUIWindow
+  public class GUIUserFavoriteShows : GUIWindow
   {
     #region Skin Controls
 
@@ -39,22 +39,19 @@ namespace TraktPlugin.GUI
 
     enum ContextMenuItem
     {
+      ShowSeasonInfo,
       RemoveFromFavorites,
       AddToFavorites,
       RemoveFromWatchList,
       AddToWatchList,
       AddToList,
-      ChangeLayout,
-      MarkAsWatched,
-      MarkAsUnWatched,
-      AddToLibrary,
-      RemoveFromLibrary,
+      Trailers,
       Related,
       Rate,
       Shouts,
       Cast,
       Crew,
-      Trailers,
+      ChangeLayout,
       SearchWithMpNZB,
       SearchTorrent
     }
@@ -63,11 +60,13 @@ namespace TraktPlugin.GUI
 
     #region Constructor
 
-    public GUIFavoriteMovies()
+    public GUIUserFavoriteShows()
     {
-      backdrop = new ImageSwapper();
-      backdrop.PropertyOne = "#Trakt.UserFavoriteMovies.Fanart.1";
-      backdrop.PropertyTwo = "#Trakt.UserFavoriteMovies.Fanart.2";
+      backdrop = new ImageSwapper
+      {
+        PropertyOne = "#Trakt.UserFavoriteShows.Fanart.1",
+        PropertyTwo = "#Trakt.UserFavoriteShows.Fanart.2"
+      };
     }
 
     #endregion
@@ -80,7 +79,7 @@ namespace TraktPlugin.GUI
     static DateTime LastRequest = new DateTime();
     static readonly Dictionary<string, IEnumerable<TraktFavoriteItem>> userFavorites = new Dictionary<string, IEnumerable<TraktFavoriteItem>>();
 
-    static IEnumerable<TraktFavoriteItem> FavoriteMovies
+    static IEnumerable<TraktFavoriteItem> FavoriteShows
     {
       get
       {
@@ -90,7 +89,7 @@ namespace TraktPlugin.GUI
 
           // NB: since we're returning all items there is no need to use the sortby API parameters for each page request
           int maxItemsPerPage = 100;
-          TraktFavoriteItems favoriteItems = TraktAPI.TraktAPI.GetFavourites( username, type: "movies", extendedInfoParams: "full", page: 1, maxItems: maxItemsPerPage );
+          TraktFavoriteItems favoriteItems = TraktAPI.TraktAPI.GetFavourites( username, type: "shows", extendedInfoParams: "full", page: 1, maxItems: maxItemsPerPage );
 
           if ( favoriteItems == null || favoriteItems.Items == null )
           {
@@ -98,27 +97,27 @@ namespace TraktPlugin.GUI
             return null;
           }
 
-          _FavoriteMovies = favoriteItems.Items;
+          _FavoriteShows = favoriteItems.Items;
 
           // get next page(s) if required
           while ( favoriteItems.CurrentPage < favoriteItems.TotalPages )
           {
-            // Note: API returns total pages for all watchlist types not just this one (movies)
+            // Note: API returns total pages for all watchlist types not just this one (shows)
             // so we need to check returned items against our expected max items per page
-            if ( _FavoriteMovies.Count() < ( maxItemsPerPage * favoriteItems.CurrentPage ) )
+            if ( _FavoriteShows.Count() < ( maxItemsPerPage * favoriteItems.CurrentPage ) )
               break;
 
-            favoriteItems = TraktAPI.TraktAPI.GetFavourites( username, type: "movies", extendedInfoParams: "full", page: favoriteItems.CurrentPage + 1, maxItems: maxItemsPerPage );
+            favoriteItems = TraktAPI.TraktAPI.GetFavourites( username, type: "shows", extendedInfoParams: "full", page: favoriteItems.CurrentPage + 1, maxItems: maxItemsPerPage );
             if ( favoriteItems == null || favoriteItems.Items == null )
               break;
 
-            _FavoriteMovies = _FavoriteMovies.Concat( favoriteItems.Items );
+            _FavoriteShows = _FavoriteShows.Concat( favoriteItems.Items );
           }
 
           if ( userFavorites.Keys.Contains( CurrentUser ) )
             userFavorites.Remove( CurrentUser );
 
-          userFavorites.Add( CurrentUser, _FavoriteMovies );
+          userFavorites.Add( CurrentUser, _FavoriteShows );
           LastRequest = DateTime.UtcNow;
           PreviousSelectedIndex = 0;
         }
@@ -126,7 +125,7 @@ namespace TraktPlugin.GUI
         return userFavorites[ CurrentUser ];
       }
     }
-    static IEnumerable<TraktFavoriteItem> _FavoriteMovies = null;
+    static IEnumerable<TraktFavoriteItem> _FavoriteShows = null;
 
     #endregion
 
@@ -142,13 +141,13 @@ namespace TraktPlugin.GUI
     {
       get
       {
-        return (int)TraktGUIWindows.UserFavoriteMovies;
+        return (int)TraktGUIWindows.UserFavoriteShows;
       }
     }
 
     public override bool Init()
     {
-      return Load( GUIGraphicsContext.Skin + @"\Trakt.UserFavorite.Movies.xml" );
+      return Load( GUIGraphicsContext.Skin + @"\Trakt.UserFavorite.Shows.xml" );
     }
 
     protected override void OnPageLoad()
@@ -165,18 +164,18 @@ namespace TraktPlugin.GUI
       // Init Properties
       InitProperties();
 
-      // Load Favorite Movies
-      LoadFavoriteMovies();
+      // Load Favorite Shows
+      LoadFavoriteShows();
     }
 
     protected override void OnPageDestroy( int new_windowId )
     {
-      GUIMovieListItem.StopDownload = true;
+      GUIShowListItem.StopDownload = true;
       PreviousSelectedIndex = Facade.SelectedListItemIndex;
       ClearProperties();
 
       // save current layout
-      TraktSettings.UserFavoriteMoviesDefaultLayout = (int)CurrentLayout;
+      TraktSettings.UserFavoriteShowsDefaultLayout = (int)CurrentLayout;
 
       base.OnPageDestroy( new_windowId );
     }
@@ -193,7 +192,7 @@ namespace TraktPlugin.GUI
         case ( 50 ):
           if ( actionType == Action.ActionType.ACTION_SELECT_ITEM )
           {
-            CheckAndPlayMovie( true );
+            CheckAndPlayEpisode( true );
           }
           break;
 
@@ -204,15 +203,15 @@ namespace TraktPlugin.GUI
 
         // Sort Button
         case ( 8 ):
-          var newSortBy = GUICommon.ShowSortMenu( TraktSettings.SortByUserFavoriteMovies );
+          var newSortBy = GUICommon.ShowSortMenu( TraktSettings.SortByUserFavoriteShows );
           if ( newSortBy != null )
           {
-            if ( newSortBy.Field != TraktSettings.SortByUserFavoriteMovies.Field )
+            if ( newSortBy.Field != TraktSettings.SortByUserFavoriteShows.Field )
             {
-              TraktSettings.SortByUserFavoriteMovies = newSortBy;
+              TraktSettings.SortByUserFavoriteShows = newSortBy;
               PreviousSelectedIndex = 0;
               UpdateButtonState();
-              LoadFavoriteMovies();
+              LoadFavoriteShows();
             }
           }
           break;
@@ -234,7 +233,7 @@ namespace TraktPlugin.GUI
           break;
         case Action.ActionType.ACTION_PLAY:
         case Action.ActionType.ACTION_MUSIC_PLAY:
-          CheckAndPlayMovie( false );
+          CheckAndPlayEpisode( false );
           break;
         default:
           base.OnAction( action );
@@ -244,7 +243,7 @@ namespace TraktPlugin.GUI
 
     protected override void OnShowContextMenu()
     {
-      var selectedItem = this.Facade.SelectedListItem as GUIMovieListItem;
+      var selectedItem = this.Facade.SelectedListItem as GUIShowListItem;
       if ( selectedItem == null )
         return;
 
@@ -259,8 +258,14 @@ namespace TraktPlugin.GUI
       dlg.Reset();
       dlg.SetHeading( GUIUtils.PluginName() );
 
-      GUIListItem listItem = null;
+      GUIListItem listItem;
 
+      // Show Season Information
+      listItem = new GUIListItem( Translation.ShowSeasonInfo );
+      dlg.Add( listItem );
+      listItem.ItemId = (int)ContextMenuItem.ShowSeasonInfo;
+
+      // Add to Favorites / Remove from Favorites
       // only allow removal if viewing your own favorites
       if ( CurrentUser == TraktSettings.Username )
       {
@@ -268,7 +273,7 @@ namespace TraktPlugin.GUI
         dlg.Add( listItem );
         listItem.ItemId = (int)ContextMenuItem.RemoveFromFavorites;
       }
-      else if ( !selectedFavoriteItem.Movie.IsFavorited() )
+      else if ( !selectedFavoriteItem.Show.IsFavorited() )
       {
         // viewing someone else's favorites and not in yours
         listItem = new GUIListItem( Translation.AddToFavorites );
@@ -277,7 +282,7 @@ namespace TraktPlugin.GUI
       }
 
       // Add to Watchlist
-      if ( !selectedFavoriteItem.Movie.IsWatchlisted() )
+      if ( !selectedFavoriteItem.Show.IsWatchlisted() )
       {
         listItem = new GUIListItem( Translation.AddToWatchList );
         dlg.Add( listItem );
@@ -295,46 +300,13 @@ namespace TraktPlugin.GUI
       dlg.Add( listItem );
       listItem.ItemId = (int)ContextMenuItem.AddToList;
 
-      // Mark As Watched
-      if ( !selectedFavoriteItem.Movie.IsWatched() )
-      {
-        listItem = new GUIListItem( Translation.MarkAsWatched );
-        dlg.Add( listItem );
-        listItem.ItemId = (int)ContextMenuItem.MarkAsWatched;
-      }
-
-      // Mark As UnWatched
-      if ( selectedFavoriteItem.Movie.IsWatched() )
-      {
-        listItem = new GUIListItem( Translation.MarkAsUnWatched );
-        dlg.Add( listItem );
-        listItem.ItemId = (int)ContextMenuItem.MarkAsUnWatched;
-      }
-
-      // Add to Library
-      // Don't allow if it will be removed again on next sync
-      // movie could be part of a DVD collection
-      if ( !selectedFavoriteItem.Movie.IsCollected() && !TraktSettings.KeepTraktLibraryClean )
-      {
-        listItem = new GUIListItem( Translation.AddToLibrary );
-        dlg.Add( listItem );
-        listItem.ItemId = (int)ContextMenuItem.AddToLibrary;
-      }
-
-      if ( selectedFavoriteItem.Movie.IsCollected() )
-      {
-        listItem = new GUIListItem( Translation.RemoveFromLibrary );
-        dlg.Add( listItem );
-        listItem.ItemId = (int)ContextMenuItem.RemoveFromLibrary;
-      }
-
-      // Related Movies
-      listItem = new GUIListItem( Translation.RelatedMovies );
+      // Related Shows
+      listItem = new GUIListItem( Translation.RelatedShows );
       dlg.Add( listItem );
       listItem.ItemId = (int)ContextMenuItem.Related;
 
-      // Rate Movie
-      listItem = new GUIListItem( Translation.RateMovie );
+      // Rate Show
+      listItem = new GUIListItem( Translation.RateShow );
       dlg.Add( listItem );
       listItem.ItemId = (int)ContextMenuItem.Rate;
 
@@ -366,17 +338,17 @@ namespace TraktPlugin.GUI
         listItem.ItemId = (int)ContextMenuItem.Trailers;
       }
 
-      if ( !selectedFavoriteItem.Movie.IsCollected() && TraktHelper.IsMpNZBAvailableAndEnabled )
+      if ( !selectedFavoriteItem.Show.IsCollected() && TraktHelper.IsMpNZBAvailableAndEnabled )
       {
-        // Search for movie with mpNZB
+        // Search for show with mpNZB
         listItem = new GUIListItem( Translation.SearchWithMpNZB );
         dlg.Add( listItem );
         listItem.ItemId = (int)ContextMenuItem.SearchWithMpNZB;
       }
 
-      if ( !selectedFavoriteItem.Movie.IsCollected() && TraktHelper.IsMyTorrentsAvailableAndEnabled )
+      if ( !selectedFavoriteItem.Show.IsCollected() && TraktHelper.IsMyTorrentsAvailableAndEnabled )
       {
-        // Search for movie with MyTorrents
+        // Search for show with MyTorrents
         listItem = new GUIListItem( Translation.SearchTorrent );
         dlg.Add( listItem );
         listItem.ItemId = (int)ContextMenuItem.SearchTorrent;
@@ -389,48 +361,37 @@ namespace TraktPlugin.GUI
 
       switch ( dlg.SelectedId )
       {
-        case ( (int)ContextMenuItem.MarkAsWatched ):
-          TraktHelper.AddMovieToWatchHistory( selectedFavoriteItem.Movie );
-          selectedItem.IsPlayed = true;
-          OnMovieSelected( selectedItem, Facade );
-          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
-          GUIWatchListMovies.ClearCache( TraktSettings.Username );
-          break;
-
-        case ( (int)ContextMenuItem.MarkAsUnWatched ):
-          TraktHelper.RemoveMovieFromWatchHistory( selectedFavoriteItem.Movie );
-          selectedItem.IsPlayed = false;
-          OnMovieSelected( selectedItem, Facade );
-          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+        case ( (int)ContextMenuItem.ShowSeasonInfo ):
+          GUIWindowManager.ActivateWindow( (int)TraktGUIWindows.ShowSeasons, selectedFavoriteItem.Show.ToJSON() );
           break;
 
         case ( (int)ContextMenuItem.AddToWatchList ):
-          TraktHelper.AddMovieToWatchList( selectedFavoriteItem.Movie, true );
-          OnMovieSelected( selectedItem, Facade );
-          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          TraktHelper.AddShowToWatchList( selectedFavoriteItem.Show );
+          OnShowSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIShowListItem ).Images.NotifyPropertyChanged( "Poster" );
           break;
 
         case ( (int)ContextMenuItem.RemoveFromFavorites ):
           PreviousSelectedIndex = this.Facade.SelectedListItemIndex;
-          TraktHelper.RemoveMovieFromFavorites( selectedFavoriteItem.Movie, true );
-          if ( _FavoriteMovies.Count() >= 1 )
+          TraktHelper.RemoveShowFromFavorites( selectedFavoriteItem.Show );
+          if ( _FavoriteShows.Count() >= 1 )
           {
             // remove from list
-            var moviesToExcept = new List<TraktFavoriteItem>();
-            moviesToExcept.Add( selectedFavoriteItem );
-            _FavoriteMovies = FavoriteMovies?.Except( moviesToExcept );
-            userFavorites[ CurrentUser ] = _FavoriteMovies;
-            LoadFavoriteMovies();
+            var showsToExcept = new List<TraktFavoriteItem>();
+            showsToExcept.Add( selectedFavoriteItem );
+            _FavoriteShows = FavoriteShows?.Except( showsToExcept );
+            userFavorites[ CurrentUser ] = _FavoriteShows;
+            LoadFavoriteShows();
           }
           else
           {
-            // no more movies left
+            // no more shows left
             ClearProperties();
             GUIControl.ClearControl( GetID, Facade.GetID );
-            _FavoriteMovies = null;
+            _FavoriteShows = null;
             userFavorites.Remove( CurrentUser );
             // notify and exit
-            GUIUtils.ShowNotifyDialog( GUIUtils.PluginName(), Translation.NoMovieFavorites );
+            GUIUtils.ShowNotifyDialog( GUIUtils.PluginName(), Translation.NoShowFavorites );
             GUIWindowManager.ShowPreviousWindow();
             return;
           }
@@ -438,62 +399,46 @@ namespace TraktPlugin.GUI
 
         case ( (int)ContextMenuItem.RemoveFromWatchList ):
           PreviousSelectedIndex = this.Facade.SelectedListItemIndex;
-          TraktHelper.RemoveMovieFromWatchList( selectedFavoriteItem.Movie, true );
-          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          TraktHelper.RemoveShowFromWatchList( selectedFavoriteItem.Show );
+          ( Facade.SelectedListItem as GUIShowListItem ).Images.NotifyPropertyChanged( "Poster" );
           break;
 
         case ( (int)ContextMenuItem.AddToList ):
-          TraktHelper.AddRemoveMovieInUserList( selectedFavoriteItem.Movie, false );
+          TraktHelper.AddRemoveShowInUserList( selectedFavoriteItem.Show, false );
           break;
 
         case ( (int)ContextMenuItem.Trailers ):
-          GUICommon.ShowMovieTrailersMenu( selectedFavoriteItem.Movie );
-          break;
-
-        case ( (int)ContextMenuItem.AddToLibrary ):
-          TraktHelper.AddMovieToCollection( selectedFavoriteItem.Movie );
-          OnMovieSelected( selectedItem, Facade );
-          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
-          if ( CurrentUser != TraktSettings.Username )
-            GUIWatchListMovies.ClearCache( TraktSettings.Username );
-          break;
-
-        case ( (int)ContextMenuItem.RemoveFromLibrary ):
-          TraktHelper.RemoveMovieFromCollection( selectedFavoriteItem.Movie );
-          OnMovieSelected( selectedItem, Facade );
-          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
-          if ( CurrentUser != TraktSettings.Username )
-            GUIWatchListMovies.ClearCache( TraktSettings.Username );
+          GUICommon.ShowTVShowTrailersMenu( selectedFavoriteItem.Show );
           break;
 
         case ( (int)ContextMenuItem.Related ):
-          TraktHelper.ShowRelatedMovies( selectedFavoriteItem.Movie );
+          TraktHelper.ShowRelatedShows( selectedFavoriteItem.Show );
           break;
 
         case ( (int)ContextMenuItem.Rate ):
-          GUICommon.RateMovie( selectedFavoriteItem.Movie );
-          OnMovieSelected( selectedItem, Facade );
-          ( Facade.SelectedListItem as GUIMovieListItem ).Images.NotifyPropertyChanged( "Poster" );
+          GUICommon.RateShow( selectedFavoriteItem.Show );
+          OnShowSelected( selectedItem, Facade );
+          ( Facade.SelectedListItem as GUIShowListItem ).Images.NotifyPropertyChanged( "Poster" );
           if ( CurrentUser != TraktSettings.Username )
-            GUIWatchListMovies.ClearCache( TraktSettings.Username );
+            GUIWatchListShows.ClearCache( TraktSettings.Username );
           break;
 
         case ( (int)ContextMenuItem.Shouts ):
-          TraktHelper.ShowMovieShouts( selectedFavoriteItem.Movie );
+          TraktHelper.ShowTVShowShouts( selectedFavoriteItem.Show );
           break;
 
         case ( (int)ContextMenuItem.Cast ):
-          GUICreditsMovie.Movie = selectedFavoriteItem.Movie;
-          GUICreditsMovie.Type = GUICreditsMovie.CreditType.Cast;
-          GUICreditsMovie.Fanart = TmdbCache.GetMovieBackdropFilename( selectedItem.Images.MovieImages );
-          GUIWindowManager.ActivateWindow( (int)TraktGUIWindows.CreditsMovie );
+          GUICreditsShow.Show = selectedFavoriteItem.Show;
+          GUICreditsShow.Type = GUICreditsShow.CreditType.Cast;
+          GUICreditsShow.Fanart = TmdbCache.GetShowBackdropFilename( selectedItem.Images.ShowImages );
+          GUIWindowManager.ActivateWindow( (int)TraktGUIWindows.CreditsShow );
           break;
 
         case ( (int)ContextMenuItem.Crew ):
-          GUICreditsMovie.Movie = selectedFavoriteItem.Movie;
-          GUICreditsMovie.Type = GUICreditsMovie.CreditType.Crew;
-          GUICreditsMovie.Fanart = TmdbCache.GetMovieBackdropFilename( selectedItem.Images.MovieImages );
-          GUIWindowManager.ActivateWindow( (int)TraktGUIWindows.CreditsMovie );
+          GUICreditsShow.Show = selectedFavoriteItem.Show;
+          GUICreditsShow.Type = GUICreditsShow.CreditType.Crew;
+          GUICreditsShow.Fanart = TmdbCache.GetShowBackdropFilename( selectedItem.Images.ShowImages );
+          GUIWindowManager.ActivateWindow( (int)TraktGUIWindows.CreditsShow );
           break;
 
         case ( (int)ContextMenuItem.ChangeLayout ):
@@ -501,12 +446,12 @@ namespace TraktPlugin.GUI
           break;
 
         case ( (int)ContextMenuItem.SearchWithMpNZB ):
-          string loadingParam = string.Format( "search:{0}", selectedFavoriteItem.Movie.Title );
+          string loadingParam = string.Format( "search:{0}", selectedFavoriteItem.Show.Title );
           GUIWindowManager.ActivateWindow( (int)ExternalPluginWindows.MpNZB, loadingParam );
           break;
 
         case ( (int)ContextMenuItem.SearchTorrent ):
-          string loadPar = selectedFavoriteItem.Movie.Title;
+          string loadPar = selectedFavoriteItem.Show.Title;
           GUIWindowManager.ActivateWindow( (int)ExternalPluginWindows.MyTorrents, loadPar );
           break;
 
@@ -521,80 +466,80 @@ namespace TraktPlugin.GUI
 
     #region Private Methods
 
-    private void CheckAndPlayMovie( bool jumpTo )
+    private void CheckAndPlayEpisode( bool jumpTo )
     {
       var selectedItem = this.Facade.SelectedListItem;
       if ( selectedItem == null )
         return;
 
-      var selectedWatchlistItem = selectedItem.TVTag as TraktMovieWatchListItem;
-      GUICommon.CheckAndPlayMovie( jumpTo, selectedWatchlistItem.Movie );
+      var selecteItem = selectedItem.TVTag as TraktFavoriteItem;
+      GUICommon.CheckAndPlayFirstUnwatchedEpisode( selecteItem.Show, jumpTo );
     }
 
-    private void LoadFavoriteMovies()
+    private void LoadFavoriteShows()
     {
       GUIUtils.SetProperty( "#Trakt.Items", string.Empty );
 
       GUIBackgroundTask.Instance.ExecuteInBackgroundAndCallback( () =>
       {
-        return FavoriteMovies;
+        return FavoriteShows;
       },
       delegate ( bool success, object result )
       {
         if ( success )
         {
           var favorites = result as IEnumerable<TraktFavoriteItem>;
-          SendFavoriteMoviesToFacade( favorites );
+          SendFavoriteShowsToFacade( favorites );
         }
       }, Translation.GettingFavorites, true );
     }
 
-    private void SendFavoriteMoviesToFacade( IEnumerable<TraktFavoriteItem> movieFavorites )
+    private void SendFavoriteShowsToFacade( IEnumerable<TraktFavoriteItem> showFavorites )
     {
       // clear facade
       GUIControl.ClearControl( GetID, Facade.GetID );
 
-      if ( movieFavorites == null )
+      if ( showFavorites == null )
       {
         GUIUtils.ShowNotifyDialog( Translation.Error, Translation.ErrorGeneral );
         GUIWindowManager.ShowPreviousWindow();
         return;
       }
 
-      if ( movieFavorites.Count() == 0 )
+      if ( showFavorites.Count() == 0 )
       {
-        GUIUtils.ShowNotifyDialog( GUIUtils.PluginName(), string.Format( Translation.NoMovieFavorites, CurrentUser ) );
+        GUIUtils.ShowNotifyDialog( GUIUtils.PluginName(), string.Format( Translation.NoShowFavorites, CurrentUser ) );
         CurrentUser = TraktSettings.Username;
         GUIWindowManager.ShowPreviousWindow();
         return;
       }
 
-      // sort movies
-      var sortedList = movieFavorites.Where( m => !string.IsNullOrEmpty( m.Movie.Title ) ).ToList();
-      sortedList.Sort( new GUIListItemMovieSorter( TraktSettings.SortByUserFavoriteMovies.Field, TraktSettings.SortByUserFavoriteMovies.Direction ) );
+      // sort shows
+      var sortedList = showFavorites.Where( s => !string.IsNullOrEmpty( s.Show.Title ) ).ToList();
+      sortedList.Sort( new GUIListItemShowSorter( TraktSettings.SortByUserFavoriteShows.Field, TraktSettings.SortByUserFavoriteShows.Direction ) );
 
       int itemId = 0;
-      var movieImages = new List<GUITmdbImage>();
+      var showImages = new List<GUITmdbImage>();
 
-      // Add each movie
+      // Add each show
       foreach ( var favoriteItem in sortedList )
       {
         // add image for download
-        var images = new GUITmdbImage { MovieImages = new TmdbMovieImages { Id = favoriteItem.Movie.Ids.Tmdb } };
-        movieImages.Add( images );
+        var images = new GUITmdbImage { ShowImages = new TmdbShowImages { Id = favoriteItem.Show.Ids.Tmdb } };
+        showImages.Add( images );
 
-        var item = new GUIMovieListItem( favoriteItem.Movie.Title, (int)TraktGUIWindows.UserFavoriteMovies );
+        var item = new GUIShowListItem( favoriteItem.Show.Title, (int)TraktGUIWindows.UserFavoriteShows );
 
-        item.Label2 = favoriteItem.Movie.Year == null ? "----" : favoriteItem.Movie.Year.ToString();
+        item.Label2 = favoriteItem.Show.Year == null ? "----" : favoriteItem.Show.Year.ToString();
         item.TVTag = favoriteItem;
-        item.Movie = favoriteItem.Movie;
+        item.Show = favoriteItem.Show;
         item.Images = images;
         item.ItemId = Int32.MaxValue - itemId;
-        item.IsPlayed = favoriteItem.Movie.IsWatched();
+        item.IsPlayed = favoriteItem.Show.IsWatched();
         item.IconImage = GUIImageHandler.GetDefaultPoster( false );
         item.IconImageBig = GUIImageHandler.GetDefaultPoster();
         item.ThumbnailImage = GUIImageHandler.GetDefaultPoster();
-        item.OnItemSelected += OnMovieSelected;
+        item.OnItemSelected += OnShowSelected;
         Utils.SetDefaultIcons( item );
         Facade.Add( item );
         itemId++;
@@ -604,17 +549,17 @@ namespace TraktPlugin.GUI
       Facade.CurrentLayout = CurrentLayout;
       GUIControl.FocusControl( GetID, Facade.GetID );
 
-      if ( PreviousSelectedIndex >= movieFavorites.Count() )
+      if ( PreviousSelectedIndex >= showFavorites.Count() )
         Facade.SelectIndex( PreviousSelectedIndex - 1 );
       else
         Facade.SelectIndex( PreviousSelectedIndex );
 
       // set facade properties
-      GUIUtils.SetProperty( "#itemcount", movieFavorites.Count().ToString() );
-      GUIUtils.SetProperty( "#Trakt.Items", string.Format( "{0} {1}", movieFavorites.Count().ToString(), movieFavorites.Count() > 1 ? Translation.Movies : Translation.Movie ) );
+      GUIUtils.SetProperty( "#itemcount", showFavorites.Count().ToString() );
+      GUIUtils.SetProperty( "#Trakt.Items", string.Format( "{0} {1}", showFavorites.Count().ToString(), showFavorites.Count() > 1 ? Translation.Shows : Translation.Show ) );
 
-      // Download movie images Async and set to facade
-      GUIMovieListItem.GetImages( movieImages );
+      // Download show images Async and set to facade
+      GUIShowListItem.GetImages( showImages );
     }
 
     private void InitProperties()
@@ -624,13 +569,13 @@ namespace TraktPlugin.GUI
       backdrop.GUIImageTwo = FanartBackground2;
       backdrop.LoadingImage = loadingImage;
 
-      // load Favorite movies for user
+      // load Favorite shows for user
       if ( string.IsNullOrEmpty( CurrentUser ) )
         CurrentUser = TraktSettings.Username;
-      GUICommon.SetProperty( "#Trakt.FavoriteMovies.CurrentUser", CurrentUser );
+      GUICommon.SetProperty( "#Trakt.FavoriteShows.CurrentUser", CurrentUser );
 
       // load last layout
-      CurrentLayout = (GUIFacadeControl.Layout)TraktSettings.UserFavoriteMoviesDefaultLayout;
+      CurrentLayout = (GUIFacadeControl.Layout)TraktSettings.UserFavoriteShowsDefaultLayout;
 
       // Update Button States
       UpdateButtonState();
@@ -639,10 +584,10 @@ namespace TraktPlugin.GUI
       {
         sortButton.SortChanged += ( o, e ) =>
         {
-          TraktSettings.SortByUserFavoriteMovies.Direction = (SortingDirections)( e.Order - 1 );
+          TraktSettings.SortByUserFavoriteShows.Direction = (SortingDirections)( e.Order - 1 );
           PreviousSelectedIndex = 0;
           UpdateButtonState();
-          LoadFavoriteMovies();
+          LoadFavoriteShows();
         };
       }
     }
@@ -655,34 +600,34 @@ namespace TraktPlugin.GUI
       // update sortby button label
       if ( sortButton != null )
       {
-        sortButton.Label = GUICommon.GetSortByString( TraktSettings.SortByUserFavoriteMovies );
-        sortButton.IsAscending = ( TraktSettings.SortByUserFavoriteMovies.Direction == SortingDirections.Ascending );
+        sortButton.Label = GUICommon.GetSortByString( TraktSettings.SortByUserFavoriteShows );
+        sortButton.IsAscending = ( TraktSettings.SortByUserFavoriteShows.Direction == SortingDirections.Ascending );
       }
-      GUIUtils.SetProperty( "#Trakt.SortBy", GUICommon.GetSortByString( TraktSettings.SortByUserFavoriteMovies ) );
+      GUIUtils.SetProperty( "#Trakt.SortBy", GUICommon.GetSortByString( TraktSettings.SortByUserFavoriteShows ) );
     }
 
     private void ClearProperties()
     {
-      GUIUtils.SetProperty( "#Trakt.Movie.Favorite.Inserted", string.Empty );
-      GUIUtils.SetProperty( "#Trakt.Movie.Favorite.Notes", string.Empty );
-      GUICommon.ClearMovieProperties();
+      GUIUtils.SetProperty( "#Trakt.Show.Favorite.Inserted", string.Empty );
+      GUIUtils.SetProperty( "#Trakt.Show.Favorite.Notes", string.Empty );
+      GUICommon.ClearShowProperties();
     }
 
     private void PublishFavoriteSkinProperties( TraktFavoriteItem item )
     {
-      GUICommon.SetProperty( "#Trakt.Movie.Favorite.Inserted", item.ListedAt.FromISO8601().ToShortDateString() );
-      GUICommon.SetProperty( "#Trakt.Movie.Favorite.Notes", item.Notes );
-      GUICommon.SetMovieProperties( item.Movie );
+      GUICommon.SetProperty( "#Trakt.Show.Favorite.Inserted", item.ListedAt.FromISO8601().ToShortDateString() );
+      GUICommon.SetProperty( "#Trakt.Show.Favorite.Notes", item.Notes );
+      GUICommon.SetShowProperties( item.Show );
     }
 
-    private void OnMovieSelected( GUIListItem item, GUIControl parent )
+    private void OnShowSelected( GUIListItem item, GUIControl parent )
     {
       PreviousSelectedIndex = Facade.SelectedListItemIndex;
 
       var favoriteItem = item.TVTag as TraktFavoriteItem;
       PublishFavoriteSkinProperties( favoriteItem );
 
-      string fanart = TmdbCache.GetMovieBackdropFilename( ( item as GUIMovieListItem ).Images.MovieImages );
+      string fanart = TmdbCache.GetShowBackdropFilename( ( item as GUIShowListItem ).Images.ShowImages );
       if ( !string.IsNullOrEmpty( fanart ) )
       {
         GUIImageHandler.LoadFanart( backdrop, fanart );

--- a/TraktPlugin/Resources/Languages/en-US.xml
+++ b/TraktPlugin/Resources/Languages/en-US.xml
@@ -158,6 +158,7 @@
   <string name="Country">Country</string>
   <string name="CostumeAndMakeUp">Costume and Make-up</string>
   <string name="CurrentPage">Current Page</string>
+  <string name="CurrentPeriod">Period: {0}</string>
   <string name="CustomLists">Custom Lists</string>
   <string name="Crew">Crew</string>
   <!--D-->
@@ -243,6 +244,12 @@
   <string name="FollowPendingApproval">Follow request has been sent to {0} and is pending approval</string>
   <string name="FriendRequestMessage">You have {0} friend requests, approve or deny from friends window</string>
   <string name="FollowerRequestMessage">You have {0} follower requests, approve or deny from network window</string>
+  <string name="FavoritedMovies">Favorited Movies</string>
+  <string name="FavoritedShows">Favorited Shows</string>
+  <string name="FavoriteMovies">Favorite Movies</string>
+  <string name="FavoriteShows">Favorite Shows</string>
+  <string name="FavoriteSeasons">Favorite Seasons</string>
+  <string name="FavoriteEpisodes">Favorite Episodes</string>
   <string name="FullName">Full Name</string>
   <!--G-->
   <string name="Gaffer">Gaffer</string>
@@ -293,6 +300,7 @@
   <string name="GettingBoxOffice">Getting Box Office</string>
   <string name="GettingCalendar">Getting Calendar</string>
   <string name="GettingEpisodes">Getting Episodes</string>
+  <string name="GettingFavorites">Getting Favorites</string>
   <string name="GettingFriendsList">Getting Friends List</string>
   <string name="GettingFollowingList">Getting Following List</string>
   <string name="GettingFollowerList">Getting Follower List</string>
@@ -311,6 +319,8 @@
   <string name="GettingShowSeasons">Getting Show Seasons</string>
   <string name="GettingTrendingMovies">Getting Trending Movies</string>
   <string name="GettingTrendingShows">Getting Trending Shows</string>
+  <string name="GettingFavoritedMovies">Getting Favorited Movies</string>
+  <string name="GettingFavoritedShows">Getting Favorited Shows</string>
   <string name="GettingPopularMovies">Getting Popular Movies</string>
   <string name="GettingPopularShows">Getting Popular Shows</string>
   <string name="GettingRecommendedMovies">Getting Recommended Movies</string>
@@ -443,11 +453,15 @@
   <string name="NoFollowingTaunt">You are not following anyone!</string>
   <string name="NoTrendingMovies">No movies currently being watched!</string>
   <string name="NoTrendingShows">No shows currently being watched!</string>
+  <string name="NoFavoritedMovies">No Favorited Movies Found!</string>
+  <string name="NoFavoritedShows">No Favorited Shows Found!</string>
   <string name="NoMovieRecommendations">No movie recommendations found!</string>
   <string name="NoShowRecommendations">No show recommendations found!</string>
   <string name="NoShowWatchList">{0} has no shows in watchlist!</string>
   <string name="NoMovieWatchList">{0} has no movies in watchlist!</string>
   <string name="NoEpisodeWatchList">{0} has no episodes in watchlist!</string>
+  <string name="NoMovieFavorites">{0} has no movies in Favorites!</string>
+  <string name="NoShowFavorites">{0} has no shows in Favorites!</string>
   <string name="NoSearchTypesSelected">You must first select one or more search types\nbefore performing an online search.</string>
   <string name="NoShoutsForItem">No shouts for {0}!</string>
   <string name="NoPeopleToSearch">There are no people to search by.</string>
@@ -480,6 +494,11 @@
   <string name="PersonSummary">Person Summary</string>
   <string name="Percentage">Percentage</string>
   <string name="Protected">Protected</string>
+  <string name="Period">Period</string>
+  <string name="PeriodDaily">Daily</string>
+  <string name="PeriodWeekly">Weekly</string>
+  <string name="PeriodMonthly">Monthly</string>
+  <string name="PeriodAll">All</string>
   <string name="PersonWatching">1 Person Watching</string>
   <string name="PeopleWatching">{0} People Watching</string>
   <string name="Plays">Plays</string>
@@ -780,6 +799,7 @@
   <string name="UserProfile">User Profile</string>
   <string name="UserRatingsDistribution">Ratings distribution 1 to 10 hearts</string>
   <string name="UserLoginSuccess">User {0} successfully authorized to use trakt account</string>
+  <string name="UserCount">User Count</string>
   <!--V-->
   <string name="VideoAssistOperator">Video Assist Operator</string>
   <string name="VisualDevelopment">Visual Development</string>

--- a/TraktPlugin/Resources/Skins/Titan/Trakt.Common.Movies.xml
+++ b/TraktPlugin/Resources/Skins/Titan/Trakt.Common.Movies.xml
@@ -218,7 +218,7 @@
       <label>#Trakt.Translation.Genre.Label</label>
       <posX>565</posX>
       <posY>487</posY>
-      <visible>facadeview.list+!string.equals(#Trakt.Movie.Genres,)+[!window.istopmost(87266)+!window.istopmost(87601)+!window.istopmost(87605)+!window.istopmost(87607)]</visible>
+      <visible>facadeview.list+!string.equals(#Trakt.Movie.Genres,)+[!window.istopmost(87266)+!window.istopmost(87601)+!window.istopmost(87605)+![window.istopmost(87607) | window.istopmost(87703)]]</visible>
       <animation effect="fade" time="250">WindowOpen</animation>
       <animation effect="fade" time="250">WindowClose</animation>
     </control>
@@ -229,7 +229,7 @@
       <label>#Trakt.Movie.Genres</label>
       <posX>798</posX>
       <posY>487</posY>
-      <visible>facadeview.list+!string.equals(#Trakt.Movie.Genres,)+[!window.istopmost(87266)+!window.istopmost(87601)+!window.istopmost(87605)+!window.istopmost(87607)]</visible>
+      <visible>facadeview.list+!string.equals(#Trakt.Movie.Genres,)+[!window.istopmost(87266)+!window.istopmost(87601)+!window.istopmost(87605)+![window.istopmost(87607) | window.istopmost(87703)]]</visible>
       <animation effect="fade" time="250">WindowOpen</animation>
       <animation effect="fade" time="250">WindowClose</animation>
     </control>
@@ -252,6 +252,28 @@
       <posX>798</posX>
       <posY>487</posY>
       <visible>facadeview.list+!string.equals(#Trakt.Movie.Watchers,)+window.istopmost(87266)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control Style="InfoLabel">
+      <description>UserCount Label (Favorited)</description>
+      <id>0</id>
+      <type>label</type>
+      <label>#Trakt.Translation.UserCount.Label</label>
+      <posX>565</posX>
+      <posY>487</posY>
+      <visible>facadeview.list+!string.equals(#Trakt.Movie.UserCount,)+window.istopmost(87703)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control Style="InfoValueSmall">
+      <description>UserCount (Favorited)</description>
+      <id>0</id>
+      <type>label</type>
+      <label>#Trakt.Movie.UserCount</label>
+      <posX>798</posX>
+      <posY>487</posY>
+      <visible>facadeview.list+!string.equals(#Trakt.Movie.UserCount,)+window.istopmost(87703)</visible>
       <animation effect="fade" time="250">WindowOpen</animation>
       <animation effect="fade" time="250">WindowClose</animation>
     </control>

--- a/TraktPlugin/Resources/Skins/Titan/Trakt.Common.Shows.xml
+++ b/TraktPlugin/Resources/Skins/Titan/Trakt.Common.Shows.xml
@@ -205,7 +205,7 @@
       <label>#Trakt.Translation.Genre.Label</label>
       <posX>565</posX>
       <posY>487</posY>
-      <visible>facadeview.list+!string.equals(#Trakt.Show.Title,)+[!window.istopmost(87265)+!window.istopmost(87602)+!window.istopmost(87606)]</visible>
+      <visible>facadeview.list+!string.equals(#Trakt.Show.Title,)+[!window.istopmost(87265)+!window.istopmost(87602)+![window.istopmost(87606) | window.istopmost(87704)]]</visible>
       <animation effect="fade" time="250">WindowOpen</animation>
       <animation effect="fade" time="250">WindowClose</animation>
     </control>
@@ -217,7 +217,7 @@
       <label>#Trakt.Show.Genres</label>
       <posX>798</posX>
       <posY>487</posY>
-      <visible>facadeview.list+!string.equals(#Trakt.Show.Title,)+[!window.istopmost(87265)+!window.istopmost(87602)+!window.istopmost(87606)]</visible>
+      <visible>facadeview.list+!string.equals(#Trakt.Show.Title,)+[!window.istopmost(87265)+!window.istopmost(87602)+![window.istopmost(87606) | window.istopmost(87704)]]</visible>
       <animation effect="fade" time="250">WindowOpen</animation>
       <animation effect="fade" time="250">WindowClose</animation>
     </control>
@@ -243,6 +243,30 @@
       <animation effect="fade" time="250">WindowOpen</animation>
       <animation effect="fade" time="250">WindowClose</animation>
     </control>
+    
+    <control Style="InfoLabel">
+      <description>UserCount Label (Favorited)</description>
+      <id>0</id>
+      <type>label</type>
+      <label>#Trakt.Translation.UserCount.Label</label>
+      <posX>565</posX>
+      <posY>487</posY>
+      <visible>facadeview.list+!string.equals(#Trakt.Show.UserCount,)+window.istopmost(87704)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control Style="InfoValueSmall">
+      <description>UserCount (Favorited)</description>
+      <id>0</id>
+      <type>label</type>
+      <label>#Trakt.Show.UserCount</label>
+      <posX>798</posX>
+      <posY>487</posY>
+      <visible>facadeview.list+!string.equals(#Trakt.Show.UserCount,)+window.istopmost(87704)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    
     <control Style="InfoLabel">
       <description>Lists Label</description>
       <id>0</id>

--- a/TraktPlugin/Resources/Skins/Titan/Trakt.Favorited.Movies.xml
+++ b/TraktPlugin/Resources/Skins/Titan/Trakt.Favorited.Movies.xml
@@ -1,0 +1,515 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>87703</id>
+  <defaultcontrol>50</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <define>#Fanart.1:#Trakt.FavoritedMovies.Fanart.1</define>
+  <define>#Fanart.2:#Trakt.FavoritedMovies.Fanart.2</define>
+  <define>#header.label:#Trakt.Translation.FavoritedMovies.Label</define>
+  <controls>
+    <!-- #fanarthandler.movie.genres.selected -->
+    <control>
+      <description>DEFAULT BACKGROUND</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>background.png</texture>
+      <shouldCache>true</shouldCache>
+    </control>
+    <import>Trakt.Common.Fanart.xml</import>
+    <!--            :: BACKGROUNDS ::           	 -->
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>fanart_overlay.png</texture>
+      <visible>!Control.IsVisible(51)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_list.png</texture>
+      <visible>facadeview.list + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background thumbs</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_tvseries_widebanner.6x2.png</texture>
+      <visible>[facadeview.smallicons | facadeview.largeicons] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>279</posY>
+      <width>1920</width>
+      <height>801</height>
+      <texture>filmstrip_overlay.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>52</posX>
+      <posY>958</posY>
+      <width>1820</width>
+      <height>84</height>
+      <texture>BasicHomeSubBG.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>66</posX>
+      <posY>34</posY>
+      <width>61</width>
+      <height>60</height>
+      <texture>icon_movies.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <import>common.time.xml</import>
+    <control>
+      <description>Period</description>
+      <type>label</type>
+      <label>#Trakt.FavoritedMovies.Period</label>
+      <id>0</id>
+      <posX>144</posX>
+      <posY>94</posY>
+      <width>1100</width>
+      <align>left</align>
+      <textcolor>FFFFFFFF</textcolor>
+      <font>TitanLight12</font>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!--            :: Count ::            -->
+    <control>
+      <description>Moviecount</description>
+      <type>label</type>
+      <label>#Trakt.Translation.Movies.Label: #itemcount</label>
+      <id>0</id>
+      <posX>96</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <font>TitanLight12</font>
+      <textcolor>000000</textcolor>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <!--            :: Listview Lines ::            -->
+    <control>
+      <description>List Lines</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>1222</posX>
+      <posY>385</posY>
+      <width>607</width>
+      <height>506</height>
+      <texture>list_lines.png</texture>
+      <visible>facadeview.list + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>group element</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <control>
+        <type>facadeview</type>
+        <id>50</id>
+        <control>
+          <description>Movie List</description>
+          <type>listcontrol</type>
+          <id>50</id>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <scrollOffset>1</scrollOffset>
+          <posX>1165</posX>
+          <posY>331</posY>
+          <height>700</height>
+          <width>698</width>
+          <textXOff>44</textXOff>
+          <textXOff2>650</textXOff2>
+          <textureHeight>54</textureHeight>
+          <textureFocus>listcontrol_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <dimColor>ffffffff</dimColor>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+        </control>
+        <control>
+          <description>Filmstrip view</description>
+          <type>filmstrip</type>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <scrollOffset>3</scrollOffset>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <posX>130</posX>
+          <posY>595</posY>
+          <width>1700</width>
+          <height>340</height>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <thumbWidth>230</thumbWidth>
+          <thumbHeight>327</thumbHeight>
+          <thumbPosX>0</thumbPosX>
+          <thumbPosY>0</thumbPosY>
+          <itemWidth>240</itemWidth>
+          <itemHeight>327</itemHeight>
+          <textureWidth>230</textureWidth>
+          <textureHeight>327</textureHeight>
+          <textYOff>-2000</textYOff>
+          <imageFolderFocus>-</imageFolderFocus>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <background>-</background>
+          <thumbs flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></thumbs>
+          <showFrame>yes</showFrame>
+          <showFolder>no</showFolder>
+          <showBackGround>no</showBackGround>
+          <showInfoImage>no</showInfoImage>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <keepaspectratio>no</keepaspectratio>
+          <thumbAnimation effect="zoom" acceleration="-2" start="100,100" reversible="false" end="120,120" center="0,880" time="200">focus</thumbAnimation>
+          <thumbAnimation effect="zoom" start="120,120" reversible="false" end="100,100" center="0,880" time="100">unfocus</thumbAnimation>
+        </control>
+        <control>
+          <description>Thumbnail Panel</description>
+          <type>thumbnailpanel</type>
+          <id>50</id>
+          <posX>754</posX>
+          <posY>342</posY>
+          <width>1150</width>
+          <height>700</height>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <itemWidth>138</itemWidth>
+          <itemHeight>196</itemHeight>
+          <textureWidth>138</textureWidth>
+          <textureHeight>196</textureHeight>
+          <thumbWidth>128</thumbWidth>
+          <thumbHeight>186</thumbHeight>
+          <thumbPosX>6</thumbPosX>
+          <thumbPosY>5</thumbPosY>
+          <itemWidthBig>214</itemWidthBig>
+          <itemHeightBig>304</itemHeightBig>
+          <thumbWidthBig>204</thumbWidthBig>
+          <thumbHeightBig>294</thumbHeightBig>
+          <textureWidthBig>216</textureWidthBig>
+          <textureHeightBig>304</textureHeightBig>
+          <thumbPosXBig>6</thumbPosXBig>
+          <thumbPosYBig>5</thumbPosYBig>
+          <zoomXPixels>0</zoomXPixels>
+          <zoomYPixels>0</zoomYPixels>
+          <hideUnfocusTexture>no</hideUnfocusTexture>
+          <keepaspectratio>no</keepaspectratio>
+          <renderFocusText>no</renderFocusText>
+          <renderUnfocusText>no</renderUnfocusText>
+          <frameNoFocus>-</frameNoFocus>
+          <frameFocus>video_thumb_focus.png</frameFocus>
+          <textureMask></textureMask>
+          <shadowAngle>90</shadowAngle>
+          <shadowDistance>50</shadowDistance>
+          <thumbZoom>no</thumbZoom>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <unfocusedAlpha>100</unfocusedAlpha>
+        </control>
+        <control>
+          <description>Cover Flow view</description>
+          <type>coverflow</type>
+          <colordiffuse>90ffffff</colordiffuse>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <posX>0</posX>
+          <posY>595</posY>
+          <width>1920</width>
+          <height>340</height>
+          <selectedCard>0</selectedCard>
+          <cardWidth>238</cardWidth>
+          <cardHeight>340</cardHeight>
+          <angle>55</angle>
+          <sideShift>150</sideShift>
+          <sideGap>120</sideGap>
+          <sideDepth>110</sideDepth>
+          <offsetY>0</offsetY>
+          <selectedOffsetY>0</selectedOffsetY>
+          <speed>10</speed>
+          <showFrame>yes</showFrame>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <keepaspectratio>no</keepaspectratio>
+          <frameWidth>238</frameWidth>
+          <frameHeight>340</frameHeight>
+          <spinSpeed>8</spinSpeed>
+          <unfocusedAlpha>FF</unfocusedAlpha>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <font1>font13</font1>
+          <font2>font11</font2>
+          <label1>#title</label1>
+          <label2>#genre</label2>
+          <textColor>FFFFFFFF</textColor>
+          <remoteColor>FFFF0000</remoteColor>
+          <playedColor>FFA0D0FF</playedColor>
+          <downloadColor>FF00FF00</downloadColor>
+          <selectedColor>FFFFFFFF</selectedColor>
+          <shadowAngle>45</shadowAngle>
+          <shadowDistance>1</shadowDistance>
+          <shadowColor>FF000000</shadowColor>
+          <label1YOff>1430</label1YOff>
+          <label2YOff>1390</label2YOff>
+          <pageSize>5</pageSize>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <cards flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></cards>
+        </control>
+      </control>
+    </control>
+    <!--            :: HIDDEN MENU ::           	 -->
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>440</posY>
+      <width>64</width>
+      <height>199</height>
+      <texture>hiddenmenu_tab.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons]+Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="-60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="-60,0" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>858</posX>
+      <posY>0</posY>
+      <texture>hiddenmenu_tab_up.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="0,-60" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="0,-60" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <type>actiongroup</type>
+      <description>action menu</description>
+      <defaultcontrol>3</defaultcontrol>
+      <onexit>50</onexit>
+      <dimColor>00ffffff</dimColor>
+      <buttonX>-460</buttonX>
+      <buttonY>155</buttonY>
+      <buttonwidth>499</buttonwidth>
+      <buttonheight>1080</buttonheight>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <width>1920</width>
+        <height>1080</height>
+        <texture>semi_trans_back_hidden_menu.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="450">visible</animation>
+        <animation effect="fade" time="400">hidden</animation>
+      </control>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>0</posY>
+        <posX>0</posX>
+        <width>612</width>
+        <height>1074</height>
+        <texture>menu_bg.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <description>Menu label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>100</posY>
+        <label>924</label>
+        <font>fontB16</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>group</type>
+        <description>group element</description>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+        <posX>53</posX>
+        <posY>155</posY>
+        <layout>StackLayout(0, Vertical, true)</layout>
+        <control>
+          <description>Change Layout</description>
+          <type>button</type>
+          <id>2</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onright>50</onright>
+          <onup>12</onup>
+        </control>
+        <control>
+          <description>Sort</description>
+          <type>sortbutton</type>
+          <id>8</id>
+          <label>-</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <offsetSortButtonX>421</offsetSortButtonX>
+          <offsetSortButtonY>27</offsetSortButtonY>
+          <onright>50</onright>
+          <onleft>50</onleft>
+        </control>
+        <control>
+          <description>Time Period</description>
+          <type>button</type>
+          <id>13</id>
+          <label>-</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <offsetSortButtonX>421</offsetSortButtonX>
+          <offsetSortButtonY>27</offsetSortButtonY>
+          <onright>50</onright>
+          <onleft>50</onleft>
+        </control>
+        <control>
+          <description>Hide Watched</description>
+          <type>checkbutton</type>
+          <id>9</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideWatched.Label</label>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+        <control>
+          <description>Hide Watchlisted</description>
+          <type>checkbutton</type>
+          <id>10</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideWatchlisted.Label</label>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+        <control>
+          <description>Hide Collected</description>
+          <type>checkbutton</type>
+          <id>11</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideCollected.Label</label>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+        <control>
+          <description>Hide Rated</description>
+          <type>checkbutton</type>
+          <id>12</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideRated.Label</label>
+          <ondown>2</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+      </control>
+    </control>
+    <import>Trakt.Common.Movies.xml</import>
+    <import>common.overlay.xml</import>
+  </controls>
+</window>

--- a/TraktPlugin/Resources/Skins/Titan/Trakt.Favorited.Shows.xml
+++ b/TraktPlugin/Resources/Skins/Titan/Trakt.Favorited.Shows.xml
@@ -1,0 +1,515 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>87704</id>
+  <defaultcontrol>50</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <define>#Fanart.1:#Trakt.FavoritedShows.Fanart.1</define>
+  <define>#Fanart.2:#Trakt.FavoritedShows.Fanart.2</define>
+  <define>#header.label:#Trakt.Translation.FavoritedShows.Label</define>
+  <controls>
+    <!-- #fanarthandler.show.genres.selected -->
+    <control>
+      <description>DEFAULT BACKGROUND</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>background.png</texture>
+      <shouldCache>true</shouldCache>
+    </control>
+    <import>Trakt.Common.Fanart.xml</import>
+    <!--            :: BACKGROUNDS ::           	 -->
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>fanart_overlay.png</texture>
+      <visible>!Control.IsVisible(51)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_list.png</texture>
+      <visible>facadeview.list + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background thumbs</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_tvseries_widebanner.6x2.png</texture>
+      <visible>[facadeview.smallicons | facadeview.largeicons] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>279</posY>
+      <width>1920</width>
+      <height>801</height>
+      <texture>filmstrip_overlay.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>52</posX>
+      <posY>958</posY>
+      <width>1820</width>
+      <height>84</height>
+      <texture>BasicHomeSubBG.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>66</posX>
+      <posY>34</posY>
+      <width>61</width>
+      <height>60</height>
+      <texture>icon_movies.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <import>common.time.xml</import>
+    <control>
+      <description>Period</description>
+      <type>label</type>
+      <label>#Trakt.FavoritedShows.Period</label>
+      <id>0</id>
+      <posX>144</posX>
+      <posY>94</posY>
+      <width>1100</width>
+      <align>left</align>
+      <textcolor>FFFFFFFF</textcolor>
+      <font>TitanLight12</font>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!--            :: Count ::            -->
+    <control>
+      <description>Show Count</description>
+      <type>label</type>
+      <label>#Trakt.Translation.Shows.Label: #itemcount</label>
+      <id>0</id>
+      <posX>96</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <font>TitanLight12</font>
+      <textcolor>000000</textcolor>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <!--            :: Listview Lines ::            -->
+    <control>
+      <description>List Lines</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>1222</posX>
+      <posY>385</posY>
+      <width>607</width>
+      <height>506</height>
+      <texture>list_lines.png</texture>
+      <visible>facadeview.list + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>group element</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <control>
+        <type>facadeview</type>
+        <id>50</id>
+        <control>
+          <description>Movie List</description>
+          <type>listcontrol</type>
+          <id>50</id>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <scrollOffset>1</scrollOffset>
+          <posX>1165</posX>
+          <posY>331</posY>
+          <height>700</height>
+          <width>698</width>
+          <textXOff>44</textXOff>
+          <textXOff2>650</textXOff2>
+          <textureHeight>54</textureHeight>
+          <textureFocus>listcontrol_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <dimColor>ffffffff</dimColor>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+        </control>
+        <control>
+          <description>Filmstrip view</description>
+          <type>filmstrip</type>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <scrollOffset>3</scrollOffset>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <posX>130</posX>
+          <posY>595</posY>
+          <width>1700</width>
+          <height>340</height>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <thumbWidth>230</thumbWidth>
+          <thumbHeight>327</thumbHeight>
+          <thumbPosX>0</thumbPosX>
+          <thumbPosY>0</thumbPosY>
+          <itemWidth>240</itemWidth>
+          <itemHeight>327</itemHeight>
+          <textureWidth>230</textureWidth>
+          <textureHeight>327</textureHeight>
+          <textYOff>-2000</textYOff>
+          <imageFolderFocus>-</imageFolderFocus>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <background>-</background>
+          <thumbs flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></thumbs>
+          <showFrame>yes</showFrame>
+          <showFolder>no</showFolder>
+          <showBackGround>no</showBackGround>
+          <showInfoImage>no</showInfoImage>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <keepaspectratio>no</keepaspectratio>
+          <thumbAnimation effect="zoom" acceleration="-2" start="100,100" reversible="false" end="120,120" center="0,880" time="200">focus</thumbAnimation>
+          <thumbAnimation effect="zoom" start="120,120" reversible="false" end="100,100" center="0,880" time="100">unfocus</thumbAnimation>
+        </control>
+        <control>
+          <description>Thumbnail Panel</description>
+          <type>thumbnailpanel</type>
+          <id>50</id>
+          <posX>754</posX>
+          <posY>342</posY>
+          <width>1150</width>
+          <height>700</height>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <itemWidth>138</itemWidth>
+          <itemHeight>196</itemHeight>
+          <textureWidth>138</textureWidth>
+          <textureHeight>196</textureHeight>
+          <thumbWidth>128</thumbWidth>
+          <thumbHeight>186</thumbHeight>
+          <thumbPosX>6</thumbPosX>
+          <thumbPosY>5</thumbPosY>
+          <itemWidthBig>214</itemWidthBig>
+          <itemHeightBig>304</itemHeightBig>
+          <thumbWidthBig>204</thumbWidthBig>
+          <thumbHeightBig>294</thumbHeightBig>
+          <textureWidthBig>216</textureWidthBig>
+          <textureHeightBig>304</textureHeightBig>
+          <thumbPosXBig>6</thumbPosXBig>
+          <thumbPosYBig>5</thumbPosYBig>
+          <zoomXPixels>0</zoomXPixels>
+          <zoomYPixels>0</zoomYPixels>
+          <hideUnfocusTexture>no</hideUnfocusTexture>
+          <keepaspectratio>no</keepaspectratio>
+          <renderFocusText>no</renderFocusText>
+          <renderUnfocusText>no</renderUnfocusText>
+          <frameNoFocus>-</frameNoFocus>
+          <frameFocus>video_thumb_focus.png</frameFocus>
+          <textureMask></textureMask>
+          <shadowAngle>90</shadowAngle>
+          <shadowDistance>50</shadowDistance>
+          <thumbZoom>no</thumbZoom>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <unfocusedAlpha>100</unfocusedAlpha>
+        </control>
+        <control>
+          <description>Cover Flow view</description>
+          <type>coverflow</type>
+          <colordiffuse>90ffffff</colordiffuse>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <posX>0</posX>
+          <posY>595</posY>
+          <width>1920</width>
+          <height>340</height>
+          <selectedCard>0</selectedCard>
+          <cardWidth>238</cardWidth>
+          <cardHeight>340</cardHeight>
+          <angle>55</angle>
+          <sideShift>150</sideShift>
+          <sideGap>120</sideGap>
+          <sideDepth>110</sideDepth>
+          <offsetY>0</offsetY>
+          <selectedOffsetY>0</selectedOffsetY>
+          <speed>10</speed>
+          <showFrame>yes</showFrame>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <keepaspectratio>no</keepaspectratio>
+          <frameWidth>238</frameWidth>
+          <frameHeight>340</frameHeight>
+          <spinSpeed>8</spinSpeed>
+          <unfocusedAlpha>FF</unfocusedAlpha>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <font1>font13</font1>
+          <font2>font11</font2>
+          <label1>#title</label1>
+          <label2>#genre</label2>
+          <textColor>FFFFFFFF</textColor>
+          <remoteColor>FFFF0000</remoteColor>
+          <playedColor>FFA0D0FF</playedColor>
+          <downloadColor>FF00FF00</downloadColor>
+          <selectedColor>FFFFFFFF</selectedColor>
+          <shadowAngle>45</shadowAngle>
+          <shadowDistance>1</shadowDistance>
+          <shadowColor>FF000000</shadowColor>
+          <label1YOff>1430</label1YOff>
+          <label2YOff>1390</label2YOff>
+          <pageSize>5</pageSize>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <cards flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></cards>
+        </control>
+      </control>
+    </control>
+    <!--            :: HIDDEN MENU ::           	 -->
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>440</posY>
+      <width>64</width>
+      <height>199</height>
+      <texture>hiddenmenu_tab.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons]+Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="-60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="-60,0" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>858</posX>
+      <posY>0</posY>
+      <texture>hiddenmenu_tab_up.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="0,-60" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="0,-60" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <type>actiongroup</type>
+      <description>action menu</description>
+      <defaultcontrol>3</defaultcontrol>
+      <onexit>50</onexit>
+      <dimColor>00ffffff</dimColor>
+      <buttonX>-460</buttonX>
+      <buttonY>155</buttonY>
+      <buttonwidth>499</buttonwidth>
+      <buttonheight>1080</buttonheight>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <width>1920</width>
+        <height>1080</height>
+        <texture>semi_trans_back_hidden_menu.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="450">visible</animation>
+        <animation effect="fade" time="400">hidden</animation>
+      </control>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>0</posY>
+        <posX>0</posX>
+        <width>612</width>
+        <height>1074</height>
+        <texture>menu_bg.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <description>Menu label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>100</posY>
+        <label>924</label>
+        <font>fontB16</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>group</type>
+        <description>group element</description>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+        <posX>53</posX>
+        <posY>155</posY>
+        <layout>StackLayout(0, Vertical, true)</layout>
+        <control>
+          <description>Change Layout</description>
+          <type>button</type>
+          <id>2</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onright>50</onright>
+          <onup>12</onup>
+        </control>
+        <control>
+          <description>Sort</description>
+          <type>sortbutton</type>
+          <id>8</id>
+          <label>-</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <offsetSortButtonX>421</offsetSortButtonX>
+          <offsetSortButtonY>27</offsetSortButtonY>
+          <onright>50</onright>
+          <onleft>50</onleft>
+        </control>
+        <control>
+          <description>Time Period</description>
+          <type>button</type>
+          <id>13</id>
+          <label>-</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <offsetSortButtonX>421</offsetSortButtonX>
+          <offsetSortButtonY>27</offsetSortButtonY>
+          <onright>50</onright>
+          <onleft>50</onleft>
+        </control>
+        <control>
+          <description>Hide Watched</description>
+          <type>checkbutton</type>
+          <id>9</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideWatched.Label</label>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+        <control>
+          <description>Hide Watchlisted</description>
+          <type>checkbutton</type>
+          <id>10</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideWatchlisted.Label</label>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+        <control>
+          <description>Hide Collected</description>
+          <type>checkbutton</type>
+          <id>11</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideCollected.Label</label>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+        <control>
+          <description>Hide Rated</description>
+          <type>checkbutton</type>
+          <id>12</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideRated.Label</label>
+          <ondown>2</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+      </control>
+    </control>
+    <import>Trakt.Common.Shows.xml</import>
+    <import>common.overlay.xml</import>
+  </controls>
+</window>

--- a/TraktPlugin/Resources/Skins/Titan/Trakt.Lists.Menu.xml
+++ b/TraktPlugin/Resources/Skins/Titan/Trakt.Lists.Menu.xml
@@ -53,7 +53,7 @@
         <hyperlink>87270</hyperlink>
         <onleft>#defaultcontrol.onleft</onleft>
         <onright>#defaultcontrol.onright</onright>
-        <onup>8</onup>
+        <onup>10</onup>
       </control>
       <control Style="SettingsButtonLarge">
         <type>button</type>
@@ -74,41 +74,59 @@
         <onright>#defaultcontrol.onright</onright>
       </control>
       <control Style="SettingsButtonLarge">
-        <description>Custom Lists</description>
+        <description>Favorite Movies</description>
         <type>button</type>
         <id>5</id>
+        <label>#Trakt.Translation.FavoriteMovies.Label</label>
+        <hyperlink>87701</hyperlink>
+        <onleft>#defaultcontrol.onleft</onleft>
+        <onright>#defaultcontrol.onright</onright>
+      </control>
+      <control Style="SettingsButtonLarge">
+        <description>Favorite Shows</description>
+        <type>button</type>
+        <id>6</id>
+        <label>#Trakt.Translation.FavoriteShows.Label</label>
+        <hyperlink>87702</hyperlink>
+        <onleft>#defaultcontrol.onleft</onleft>
+        <onright>#defaultcontrol.onright</onright>
+      </control>
+      <control Style="SettingsButtonLarge">
+        <description>Custom Lists</description>
+        <type>button</type>
+        <id>7</id>
         <label>#Trakt.Translation.CustomLists.Label</label>
         <hyperlink>87275</hyperlink>
         <onleft>#defaultcontrol.onleft</onleft>
         <onright>#defaultcontrol.onright</onright>
       </control>
-	  <control Style="SettingsButtonLarge">
+      <control Style="SettingsButtonLarge">
         <description>Trending Lists</description>
         <type>button</type>
-        <id>6</id>
+        <id>8</id>
         <label>#Trakt.Translation.TrendingLists.Label</label>
         <hyperlink>87275</hyperlink>
-		<hyperlinkParameter>trending</hyperlinkParameter>
+        <hyperlinkParameter>trending</hyperlinkParameter>
         <onleft>#defaultcontrol.onleft</onleft>
         <onright>#defaultcontrol.onright</onright>
       </control>
-	  <control Style="SettingsButtonLarge">
+      <control Style="SettingsButtonLarge">
         <description>Popular Lists</description>
         <type>button</type>
-        <id>7</id>
+        <id>9</id>
         <label>#Trakt.Translation.PopularLists.Label</label>
         <hyperlink>87275</hyperlink>
-		<hyperlinkParameter>popular</hyperlinkParameter>
+        <hyperlinkParameter>popular</hyperlinkParameter>
         <onleft>#defaultcontrol.onleft</onleft>
         <onright>#defaultcontrol.onright</onright>
       </control>
-	  <control Style="SettingsButtonLarge">
+      <control Style="SettingsButtonLarge">
         <description>Liked Lists</description>
         <type>button</type>
-        <id>8</id>
+        <id>10</id>
         <label>#Trakt.Translation.LikedLists.Label</label>
         <hyperlink>87275</hyperlink>
-		<hyperlinkParameter>liked</hyperlinkParameter>
+        <hyperlinkParameter>liked</hyperlinkParameter>
         <onleft>#defaultcontrol.onleft</onleft>
         <onright>#defaultcontrol.onright</onright>
         <ondown>2</ondown>

--- a/TraktPlugin/Resources/Skins/Titan/Trakt.Movies.Menu.xml
+++ b/TraktPlugin/Resources/Skins/Titan/Trakt.Movies.Menu.xml
@@ -53,9 +53,9 @@
         <hyperlink>87266</hyperlink>
         <onleft>#defaultcontrol.onleft</onleft>
         <onright>#defaultcontrol.onright</onright>
-        <onup>7</onup>
+        <onup>8</onup>
       </control>
-	  <control Style="SettingsButtonLarge">
+      <control Style="SettingsButtonLarge">
         <type>button</type>
         <description>Calendar Movies</description>
         <id>3</id>
@@ -74,9 +74,18 @@
         <onright>#defaultcontrol.onright</onright>
       </control>
       <control Style="SettingsButtonLarge">
-        <description>Recommended Movies</description>
+        <description>Favorited Movies (Trakt Community)</description>
         <type>button</type>
         <id>5</id>
+        <label>#Trakt.Translation.Favorited.Label</label>
+        <hyperlink>87703</hyperlink>
+        <onleft>#defaultcontrol.onleft</onleft>
+        <onright>#defaultcontrol.onright</onright>
+      </control>
+      <control Style="SettingsButtonLarge">
+        <description>Recommended Movies</description>
+        <type>button</type>
+        <id>6</id>
         <label>#Trakt.Translation.Recommendations.Label</label>
         <hyperlink>87263</hyperlink>
         <onleft>#defaultcontrol.onleft</onleft>
@@ -85,7 +94,7 @@
       <control Style="SettingsButtonLarge">
         <description>Anticipated Movies</description>
         <type>button</type>
-        <id>6</id>
+        <id>7</id>
         <label>#Trakt.Translation.Anticipated.Label</label>
         <hyperlink>87605</hyperlink>
         <onleft>#defaultcontrol.onleft</onleft>
@@ -94,7 +103,7 @@
       <control Style="SettingsButtonLarge">
         <description>Box Office</description>
         <type>button</type>
-        <id>7</id>
+        <id>8</id>
         <label>#Trakt.Translation.BoxOffice.Label</label>
         <hyperlink>87607</hyperlink>
         <onleft>#defaultcontrol.onleft</onleft>

--- a/TraktPlugin/Resources/Skins/Titan/Trakt.TV.Menu.xml
+++ b/TraktPlugin/Resources/Skins/Titan/Trakt.TV.Menu.xml
@@ -53,7 +53,7 @@
         <hyperlink>87265</hyperlink>
         <onleft>#defaultcontrol.onleft</onleft>
         <onright>#defaultcontrol.onright</onright>
-        <onup>5</onup>
+        <onup>6</onup>
       </control>
       <control Style="SettingsButtonLarge">
         <description>Popular Shows</description>
@@ -63,12 +63,20 @@
         <hyperlink>87102</hyperlink>
         <onleft>#defaultcontrol.onleft</onleft>
         <onright>#defaultcontrol.onright</onright>
-        <ondown>4</ondown>
+      </control>
+      <control Style="SettingsButtonLarge">
+        <description>Favorited Shows (Trakt Community)</description>
+        <type>button</type>
+        <id>4</id>
+        <label>#Trakt.Translation.Favorited.Label</label>
+        <hyperlink>87704</hyperlink>
+        <onleft>#defaultcontrol.onleft</onleft>
+        <onright>#defaultcontrol.onright</onright>
       </control>
       <control Style="SettingsButtonLarge">
         <description>Recommended Shows</description>
         <type>button</type>
-        <id>4</id>
+        <id>5</id>
         <label>#Trakt.Translation.Recommendations.Label</label>
         <hyperlink>87262</hyperlink>
         <onleft>#defaultcontrol.onleft</onleft>
@@ -77,7 +85,7 @@
       <control Style="SettingsButtonLarge">
         <description>Anticipated Shows</description>
         <type>button</type>
-        <id>5</id>
+        <id>6</id>
         <label>#Trakt.Translation.Anticipated.Label</label>
         <hyperlink>87606</hyperlink>
         <onleft>#defaultcontrol.onleft</onleft>

--- a/TraktPlugin/Resources/Skins/Titan/Trakt.UserFavorite.Movies.xml
+++ b/TraktPlugin/Resources/Skins/Titan/Trakt.UserFavorite.Movies.xml
@@ -1,0 +1,438 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>87701</id>
+  <defaultcontrol>50</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <define>#Fanart.1:#Trakt.UserFavoriteMovies.Fanart.1</define>
+  <define>#Fanart.2:#Trakt.UserFavoriteMovies.Fanart.2</define>
+  <define>#header.label:#Trakt.Translation.FavoriteMovies.Label</define>
+  <controls>
+    <control>
+      <description>DEFAULT BACKGROUND</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>background.png</texture>
+      <shouldCache>true</shouldCache>
+    </control>
+    <import>Trakt.Common.Fanart.xml</import>
+    <!--            :: BACKGROUNDS ::           	 -->
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>fanart_overlay.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_list.png</texture>
+      <visible>facadeview.list + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background thumbs</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_tvseries_widebanner.6x2.png</texture>
+      <visible>[facadeview.smallicons | facadeview.largeicons] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>279</posY>
+      <width>1920</width>
+      <height>801</height>
+      <texture>filmstrip_overlay.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>52</posX>
+      <posY>958</posY>
+      <width>1820</width>
+      <height>84</height>
+      <texture>BasicHomeSubBG.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>66</posX>
+      <posY>34</posY>
+      <width>61</width>
+      <height>60</height>
+      <texture>icon_plugin.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <import>common.time.xml</import>
+    <control>
+      <description>Current User</description>
+      <type>label</type>
+      <label>#Trakt.FavoriteMovies.CurrentUser</label>
+      <id>0</id>
+      <posX>144</posX>
+      <posY>94</posY>
+      <align>left</align>
+      <textcolor>FFFFFFFF</textcolor>
+      <font>TitanLight12</font>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!--            :: Count ::            -->
+    <control>
+      <description>Moviecount</description>
+      <type>label</type>
+      <label>#Trakt.Translation.Movies.Label: #itemcount</label>
+      <id>0</id>
+      <posX>96</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <font>TitanLight12</font>
+      <textcolor>000000</textcolor>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <!--            :: Listview Lines ::            -->
+    <control>
+      <description>List Lines</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>1222</posX>
+      <posY>385</posY>
+      <width>607</width>
+      <height>506</height>
+      <texture>list_lines.png</texture>
+      <visible>facadeview.list + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>group element</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <control>
+        <type>facadeview</type>
+        <id>50</id>
+        <control>
+          <description>Movie List</description>
+          <type>listcontrol</type>
+          <id>50</id>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <scrollOffset>1</scrollOffset>
+          <posX>1165</posX>
+          <posY>331</posY>
+          <height>700</height>
+          <width>698</width>
+          <textXOff>44</textXOff>
+          <textXOff2>650</textXOff2>
+          <textureHeight>54</textureHeight>
+          <textureFocus>listcontrol_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <dimColor>ffffffff</dimColor>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+        </control>
+        <control>
+          <description>Filmstrip view</description>
+          <type>filmstrip</type>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <scrollOffset>3</scrollOffset>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <posX>130</posX>
+          <posY>595</posY>
+          <width>1700</width>
+          <height>340</height>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <thumbWidth>230</thumbWidth>
+          <thumbHeight>327</thumbHeight>
+          <thumbPosX>0</thumbPosX>
+          <thumbPosY>0</thumbPosY>
+          <itemWidth>240</itemWidth>
+          <itemHeight>327</itemHeight>
+          <textureWidth>230</textureWidth>
+          <textureHeight>327</textureHeight>
+          <textYOff>-2000</textYOff>
+          <imageFolderFocus>-</imageFolderFocus>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <background>-</background>
+          <thumbs flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></thumbs>
+          <showFrame>yes</showFrame>
+          <showFolder>no</showFolder>
+          <showBackGround>no</showBackGround>
+          <showInfoImage>no</showInfoImage>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <keepaspectratio>no</keepaspectratio>
+          <thumbAnimation effect="zoom" acceleration="-2" start="100,100" reversible="false" end="120,120" center="0,880" time="200">focus</thumbAnimation>
+          <thumbAnimation effect="zoom" start="120,120" reversible="false" end="100,100" center="0,880" time="100">unfocus</thumbAnimation>
+        </control>
+        <control>
+          <description>Thumbnail Panel</description>
+          <type>thumbnailpanel</type>
+          <id>50</id>
+          <posX>754</posX>
+          <posY>342</posY>
+          <width>1150</width>
+          <height>700</height>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <itemWidth>138</itemWidth>
+          <itemHeight>196</itemHeight>
+          <textureWidth>138</textureWidth>
+          <textureHeight>196</textureHeight>
+          <thumbWidth>128</thumbWidth>
+          <thumbHeight>186</thumbHeight>
+          <thumbPosX>6</thumbPosX>
+          <thumbPosY>5</thumbPosY>
+          <itemWidthBig>214</itemWidthBig>
+          <itemHeightBig>304</itemHeightBig>
+          <thumbWidthBig>204</thumbWidthBig>
+          <thumbHeightBig>294</thumbHeightBig>
+          <textureWidthBig>216</textureWidthBig>
+          <textureHeightBig>304</textureHeightBig>
+          <thumbPosXBig>6</thumbPosXBig>
+          <thumbPosYBig>5</thumbPosYBig>
+          <zoomXPixels>0</zoomXPixels>
+          <zoomYPixels>0</zoomYPixels>
+          <hideUnfocusTexture>no</hideUnfocusTexture>
+          <keepaspectratio>no</keepaspectratio>
+          <renderFocusText>no</renderFocusText>
+          <renderUnfocusText>no</renderUnfocusText>
+          <frameNoFocus>-</frameNoFocus>
+          <frameFocus>video_thumb_focus.png</frameFocus>
+          <textureMask></textureMask>
+          <shadowAngle>90</shadowAngle>
+          <shadowDistance>50</shadowDistance>
+          <thumbZoom>no</thumbZoom>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <unfocusedAlpha>100</unfocusedAlpha>
+        </control>
+        <control>
+          <description>Cover Flow view</description>
+          <type>coverflow</type>
+          <colordiffuse>90ffffff</colordiffuse>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <posX>0</posX>
+          <posY>595</posY>
+          <width>1920</width>
+          <height>340</height>
+          <selectedCard>0</selectedCard>
+          <cardWidth>238</cardWidth>
+          <cardHeight>340</cardHeight>
+          <angle>55</angle>
+          <sideShift>150</sideShift>
+          <sideGap>120</sideGap>
+          <sideDepth>110</sideDepth>
+          <offsetY>0</offsetY>
+          <selectedOffsetY>0</selectedOffsetY>
+          <speed>10</speed>
+          <showFrame>yes</showFrame>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <keepaspectratio>no</keepaspectratio>
+          <frameWidth>238</frameWidth>
+          <frameHeight>340</frameHeight>
+          <spinSpeed>8</spinSpeed>
+          <unfocusedAlpha>FF</unfocusedAlpha>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <font1>font13</font1>
+          <font2>font11</font2>
+          <label1>#title</label1>
+          <label2>#genre</label2>
+          <textColor>FFFFFFFF</textColor>
+          <remoteColor>FFFF0000</remoteColor>
+          <playedColor>FFA0D0FF</playedColor>
+          <downloadColor>FF00FF00</downloadColor>
+          <selectedColor>FFFFFFFF</selectedColor>
+          <shadowAngle>45</shadowAngle>
+          <shadowDistance>1</shadowDistance>
+          <shadowColor>FF000000</shadowColor>
+          <label1YOff>1430</label1YOff>
+          <label2YOff>1390</label2YOff>
+          <pageSize>5</pageSize>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <cards flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></cards>
+        </control>
+      </control>
+    </control>
+    <!--            :: HIDDEN MENU ::           	 -->
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>440</posY>
+      <width>64</width>
+      <height>199</height>
+      <texture>hiddenmenu_tab.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons]+Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="-60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="-60,0" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>858</posX>
+      <posY>0</posY>
+      <texture>hiddenmenu_tab_up.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="0,-60" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="0,-60" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <type>actiongroup</type>
+      <description>action menu</description>
+      <defaultcontrol>3</defaultcontrol>
+      <onexit>50</onexit>
+      <dimColor>00ffffff</dimColor>
+      <buttonX>-460</buttonX>
+      <buttonY>155</buttonY>
+      <buttonwidth>499</buttonwidth>
+      <buttonheight>1080</buttonheight>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <width>1920</width>
+        <height>1080</height>
+        <texture>semi_trans_back_hidden_menu.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="450">visible</animation>
+        <animation effect="fade" time="400">hidden</animation>
+      </control>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>0</posY>
+        <posX>0</posX>
+        <width>612</width>
+        <height>1074</height>
+        <texture>menu_bg.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <description>Menu label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>100</posY>
+        <label>924</label>
+        <font>fontB16</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>group</type>
+        <description>group element</description>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+        <posX>53</posX>
+        <posY>155</posY>
+        <layout>StackLayout(0, Vertical, true)</layout>
+        <control>
+          <description>Change Layout</description>
+          <type>button</type>
+          <id>2</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onright>50</onright>
+          <ondown>8</ondown>
+          <onup>8</onup>
+        </control>
+        <control>
+          <description>Sort</description>
+          <type>sortbutton</type>
+          <id>8</id>
+          <label>-</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <offsetSortButtonX>421</offsetSortButtonX>
+          <offsetSortButtonY>27</offsetSortButtonY>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <ondown>2</ondown>
+          <onup>2</onup>
+        </control>
+      </control>
+    </control>
+    <import>Trakt.Common.Movies.xml</import>
+    <import>common.overlay.xml</import>
+  </controls>
+</window>

--- a/TraktPlugin/Resources/Skins/Titan/Trakt.UserFavorite.Shows.xml
+++ b/TraktPlugin/Resources/Skins/Titan/Trakt.UserFavorite.Shows.xml
@@ -1,0 +1,438 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>87702</id>
+  <defaultcontrol>50</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <define>#Fanart.1:#Trakt.UserFavoriteShows.Fanart.1</define>
+  <define>#Fanart.2:#Trakt.UserFavoriteShows.Fanart.2</define>
+  <define>#header.label:#Trakt.Translation.FavoriteShows.Label</define>
+  <controls>
+    <control>
+      <description>DEFAULT BACKGROUND</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>background.png</texture>
+      <shouldCache>true</shouldCache>
+    </control>
+    <import>Trakt.Common.Fanart.xml</import>
+    <!--            :: BACKGROUNDS ::           	 -->
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>fanart_overlay.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_list.png</texture>
+      <visible>facadeview.list + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background thumbs</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_tvseries_widebanner.6x2.png</texture>
+      <visible>[facadeview.smallicons | facadeview.largeicons] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>279</posY>
+      <width>1920</width>
+      <height>801</height>
+      <texture>filmstrip_overlay.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>52</posX>
+      <posY>958</posY>
+      <width>1820</width>
+      <height>84</height>
+      <texture>BasicHomeSubBG.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>66</posX>
+      <posY>34</posY>
+      <width>61</width>
+      <height>60</height>
+      <texture>icon_plugin.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <import>common.time.xml</import>
+    <control>
+      <description>Current User</description>
+      <type>label</type>
+      <label>#Trakt.FavoriteShows.CurrentUser</label>
+      <id>0</id>
+      <posX>144</posX>
+      <posY>94</posY>
+      <align>left</align>
+      <textcolor>FFFFFFFF</textcolor>
+      <font>TitanLight12</font>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!--            :: Count ::            -->
+    <control>
+      <description>Showcount</description>
+      <type>label</type>
+      <label>#Trakt.Translation.Shows.Label: #itemcount</label>
+      <id>0</id>
+      <posX>96</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <font>TitanLight12</font>
+      <textcolor>000000</textcolor>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <!--            :: Listview Lines ::            -->
+    <control>
+      <description>List Lines</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>1222</posX>
+      <posY>385</posY>
+      <width>607</width>
+      <height>506</height>
+      <texture>list_lines.png</texture>
+      <visible>facadeview.list + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>group element</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <control>
+        <type>facadeview</type>
+        <id>50</id>
+        <control>
+          <description>Show List</description>
+          <type>listcontrol</type>
+          <id>50</id>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <scrollOffset>1</scrollOffset>
+          <posX>1165</posX>
+          <posY>331</posY>
+          <height>700</height>
+          <width>698</width>
+          <textXOff>44</textXOff>
+          <textXOff2>650</textXOff2>
+          <textureHeight>54</textureHeight>
+          <textureFocus>listcontrol_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <dimColor>ffffffff</dimColor>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+        </control>
+        <control>
+          <description>Filmstrip view</description>
+          <type>filmstrip</type>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <scrollOffset>3</scrollOffset>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <posX>130</posX>
+          <posY>595</posY>
+          <width>1700</width>
+          <height>340</height>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <thumbWidth>230</thumbWidth>
+          <thumbHeight>327</thumbHeight>
+          <thumbPosX>0</thumbPosX>
+          <thumbPosY>0</thumbPosY>
+          <itemWidth>240</itemWidth>
+          <itemHeight>327</itemHeight>
+          <textureWidth>230</textureWidth>
+          <textureHeight>327</textureHeight>
+          <textYOff>-2000</textYOff>
+          <imageFolderFocus>-</imageFolderFocus>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <background>-</background>
+          <thumbs flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></thumbs>
+          <showFrame>yes</showFrame>
+          <showFolder>no</showFolder>
+          <showBackGround>no</showBackGround>
+          <showInfoImage>no</showInfoImage>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <keepaspectratio>no</keepaspectratio>
+          <thumbAnimation effect="zoom" acceleration="-2" start="100,100" reversible="false" end="120,120" center="0,880" time="200">focus</thumbAnimation>
+          <thumbAnimation effect="zoom" start="120,120" reversible="false" end="100,100" center="0,880" time="100">unfocus</thumbAnimation>
+        </control>
+        <control>
+          <description>Thumbnail Panel</description>
+          <type>thumbnailpanel</type>
+          <id>50</id>
+          <posX>754</posX>
+          <posY>342</posY>
+          <width>1150</width>
+          <height>700</height>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <itemWidth>138</itemWidth>
+          <itemHeight>196</itemHeight>
+          <textureWidth>138</textureWidth>
+          <textureHeight>196</textureHeight>
+          <thumbWidth>128</thumbWidth>
+          <thumbHeight>186</thumbHeight>
+          <thumbPosX>6</thumbPosX>
+          <thumbPosY>5</thumbPosY>
+          <itemWidthBig>214</itemWidthBig>
+          <itemHeightBig>304</itemHeightBig>
+          <thumbWidthBig>204</thumbWidthBig>
+          <thumbHeightBig>294</thumbHeightBig>
+          <textureWidthBig>216</textureWidthBig>
+          <textureHeightBig>304</textureHeightBig>
+          <thumbPosXBig>6</thumbPosXBig>
+          <thumbPosYBig>5</thumbPosYBig>
+          <zoomXPixels>0</zoomXPixels>
+          <zoomYPixels>0</zoomYPixels>
+          <hideUnfocusTexture>no</hideUnfocusTexture>
+          <keepaspectratio>no</keepaspectratio>
+          <renderFocusText>no</renderFocusText>
+          <renderUnfocusText>no</renderUnfocusText>
+          <frameNoFocus>-</frameNoFocus>
+          <frameFocus>video_thumb_focus.png</frameFocus>
+          <textureMask></textureMask>
+          <shadowAngle>90</shadowAngle>
+          <shadowDistance>50</shadowDistance>
+          <thumbZoom>no</thumbZoom>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <unfocusedAlpha>100</unfocusedAlpha>
+        </control>
+        <control>
+          <description>Cover Flow view</description>
+          <type>coverflow</type>
+          <colordiffuse>90ffffff</colordiffuse>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <posX>0</posX>
+          <posY>595</posY>
+          <width>1920</width>
+          <height>340</height>
+          <selectedCard>0</selectedCard>
+          <cardWidth>238</cardWidth>
+          <cardHeight>340</cardHeight>
+          <angle>55</angle>
+          <sideShift>150</sideShift>
+          <sideGap>120</sideGap>
+          <sideDepth>110</sideDepth>
+          <offsetY>0</offsetY>
+          <selectedOffsetY>0</selectedOffsetY>
+          <speed>10</speed>
+          <showFrame>yes</showFrame>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <keepaspectratio>no</keepaspectratio>
+          <frameWidth>238</frameWidth>
+          <frameHeight>340</frameHeight>
+          <spinSpeed>8</spinSpeed>
+          <unfocusedAlpha>FF</unfocusedAlpha>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <font1>font13</font1>
+          <font2>font11</font2>
+          <label1>#title</label1>
+          <label2>#genre</label2>
+          <textColor>FFFFFFFF</textColor>
+          <remoteColor>FFFF0000</remoteColor>
+          <playedColor>FFA0D0FF</playedColor>
+          <downloadColor>FF00FF00</downloadColor>
+          <selectedColor>FFFFFFFF</selectedColor>
+          <shadowAngle>45</shadowAngle>
+          <shadowDistance>1</shadowDistance>
+          <shadowColor>FF000000</shadowColor>
+          <label1YOff>1430</label1YOff>
+          <label2YOff>1390</label2YOff>
+          <pageSize>5</pageSize>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <cards flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></cards>
+        </control>
+      </control>
+    </control>
+    <!--            :: HIDDEN MENU ::           	 -->
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>440</posY>
+      <width>64</width>
+      <height>199</height>
+      <texture>hiddenmenu_tab.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons]+Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="-60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="-60,0" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>858</posX>
+      <posY>0</posY>
+      <texture>hiddenmenu_tab_up.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="0,-60" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="0,-60" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <type>actiongroup</type>
+      <description>action menu</description>
+      <defaultcontrol>3</defaultcontrol>
+      <onexit>50</onexit>
+      <dimColor>00ffffff</dimColor>
+      <buttonX>-460</buttonX>
+      <buttonY>155</buttonY>
+      <buttonwidth>499</buttonwidth>
+      <buttonheight>1080</buttonheight>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <width>1920</width>
+        <height>1080</height>
+        <texture>semi_trans_back_hidden_menu.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="450">visible</animation>
+        <animation effect="fade" time="400">hidden</animation>
+      </control>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>0</posY>
+        <posX>0</posX>
+        <width>612</width>
+        <height>1074</height>
+        <texture>menu_bg.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <description>Menu label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>100</posY>
+        <label>924</label>
+        <font>fontB16</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>group</type>
+        <description>group element</description>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+        <posX>53</posX>
+        <posY>155</posY>
+        <layout>StackLayout(0, Vertical, true)</layout>
+        <control>
+          <description>Change Layout</description>
+          <type>button</type>
+          <id>2</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onright>50</onright>
+          <ondown>8</ondown>
+          <onup>8</onup>
+        </control>
+        <control>
+          <description>Sort</description>
+          <type>sortbutton</type>
+          <id>8</id>
+          <label>-</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <offsetSortButtonX>421</offsetSortButtonX>
+          <offsetSortButtonY>27</offsetSortButtonY>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <ondown>2</ondown>
+          <onup>2</onup>
+        </control>
+      </control>
+    </control>
+    <import>Trakt.Common.Shows.xml</import>
+    <import>common.overlay.xml</import>
+  </controls>
+</window>

--- a/TraktPlugin/TraktPlugin.csproj
+++ b/TraktPlugin/TraktPlugin.csproj
@@ -708,7 +708,6 @@
     <Content Include="Resources\Skins\Titan\Themes\Extended Two\BasicHome.Trakt.xml" />
     <Content Include="Resources\Skins\Titan\Themes\Extended Two\Media\BasicHomeImages\Trakt.png" />
     <Content Include="Resources\Skins\Titan\Themes\Extended Two\Trakt.SkinSettings.xml" />
-    <Content Include="Resources\Skins\Titan\Trakt.AccountDialog.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.Calendar.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.Common.Background.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.Common.Episodes.xml" />
@@ -719,6 +718,8 @@
     <Content Include="Resources\Skins\Titan\Trakt.Common.Users.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.Common.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.Dashboard.xml" />
+    <Content Include="Resources\Skins\Titan\Trakt.Favorited.Movies.xml" />
+    <Content Include="Resources\Skins\Titan\Trakt.Favorited.Shows.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.List.Items.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.Lists.Menu.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.Lists.xml" />
@@ -748,7 +749,7 @@
     <Content Include="Resources\Skins\Titan\Trakt.Search.Users.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.Search.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.Season.Episodes.xml" />
-    <Content Include="Resources\Skins\Titan\Trakt.Settings.Account.xml" />
+    <Content Include="Resources\Skins\Titan\Trakt.Settings.AccountAuth.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.Settings.General.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.Settings.Plugins.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.Settings.xml" />
@@ -759,6 +760,8 @@
     <Content Include="Resources\Skins\Titan\Trakt.Trending.Shows.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.Trending.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.TV.Menu.xml" />
+    <Content Include="Resources\Skins\Titan\Trakt.UserFavorite.Movies.xml" />
+    <Content Include="Resources\Skins\Titan\Trakt.UserFavorite.Shows.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.UserProfile.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.WatchList.Episodes.xml" />
     <Content Include="Resources\Skins\Titan\Trakt.WatchList.Movies.xml" />

--- a/TraktPlugin/TraktPlugin.csproj
+++ b/TraktPlugin/TraktPlugin.csproj
@@ -272,6 +272,7 @@
     <Compile Include="GUI\GUIRecentWatchedEpisodes.cs" />
     <Compile Include="GUI\GUIRecentWatchedMovies.cs" />
     <Compile Include="GUI\GUITVMenu.cs" />
+    <Compile Include="GUI\GUIUserFavoriteShows.cs" />
     <Compile Include="GUI\GUIUserProfile.cs" />
     <Compile Include="GUI\GUIWatchListEpisodes.cs" />
     <Compile Include="GUI\GUIRecommendationsMovies.cs" />
@@ -284,7 +285,7 @@
     <Compile Include="GUI\GUICalendarTV.cs" />
     <Compile Include="GUI\GUIExtensions.cs" />
     <Compile Include="GUI\GUIImageHandler.cs" />
-    <Compile Include="GUI\GUIFavoriteMovies.cs" />
+    <Compile Include="GUI\GUIUserFavoriteMovies.cs" />
     <Compile Include="GUI\GUIWatchListMovies.cs" />
     <Compile Include="GUI\GUIWatchListShows.cs" />
     <Compile Include="Extensions\SecurityExtensions.cs" />

--- a/TraktPlugin/TraktPlugin.csproj
+++ b/TraktPlugin/TraktPlugin.csproj
@@ -271,6 +271,7 @@
     <Compile Include="GUI\GUIShowSeasons.cs" />
     <Compile Include="GUI\GUIRecentWatchedEpisodes.cs" />
     <Compile Include="GUI\GUIRecentWatchedMovies.cs" />
+    <Compile Include="GUI\GUIFavoritedMovies.cs" />
     <Compile Include="GUI\GUITVMenu.cs" />
     <Compile Include="GUI\GUIUserFavoriteShows.cs" />
     <Compile Include="GUI\GUIUserProfile.cs" />

--- a/TraktPlugin/TraktPlugin.csproj
+++ b/TraktPlugin/TraktPlugin.csproj
@@ -284,6 +284,7 @@
     <Compile Include="GUI\GUICalendarTV.cs" />
     <Compile Include="GUI\GUIExtensions.cs" />
     <Compile Include="GUI\GUIImageHandler.cs" />
+    <Compile Include="GUI\GUIFavoriteMovies.cs" />
     <Compile Include="GUI\GUIWatchListMovies.cs" />
     <Compile Include="GUI\GUIWatchListShows.cs" />
     <Compile Include="Extensions\SecurityExtensions.cs" />

--- a/TraktPlugin/TraktPlugin.csproj
+++ b/TraktPlugin/TraktPlugin.csproj
@@ -229,6 +229,7 @@
     <Compile Include="GUI\GUICreditsMovie.cs" />
     <Compile Include="GUI\GUICreditsShow.cs" />
     <Compile Include="GUI\GUIAnticipatedShows.cs" />
+    <Compile Include="GUI\GUIFavoritedShows.cs" />
     <Compile Include="GUI\GUIListsMenu.cs" />
     <Compile Include="GUI\GUICommon.cs" />
     <Compile Include="GUI\GUIDialogMultiSelect.cs" />

--- a/TraktPlugin/TraktSettings.cs
+++ b/TraktPlugin/TraktSettings.cs
@@ -124,6 +124,14 @@ namespace TraktPlugin
         public static bool RememberLastSelectedActivity { get; set; }
         public static int MovPicsRatingDlgDelay { get; set; }
         public static bool ShowRateDlgForPlaylists { get; set; }
+        public static bool FavoritedMoviesHideWatched { get; set; }
+        public static bool FavoritedMoviesHideWatchlisted { get; set; }
+        public static bool FavoritedMoviesHideCollected { get; set; }
+        public static bool FavoritedMoviesHideRated { get; set; }
+        public static bool FavoritedShowsHideWatched { get; set; }
+        public static bool FavoritedShowsHideWatchlisted { get; set; }
+        public static bool FavoritedShowsHideCollected { get; set; }
+        public static bool FavoritedShowsHideRated { get; set; }
         public static bool TrendingMoviesHideWatched { get; set; }
         public static bool TrendingMoviesHideWatchlisted { get; set; }
         public static bool TrendingMoviesHideCollected { get; set; }
@@ -175,6 +183,8 @@ namespace TraktPlugin
         public static int SyncResumeDelta { get; set; }
         public static bool SyncPlaybackOnEnterPlugin { get; set; }
         public static int SyncPlaybackCacheExpiry { get; set; }
+        public static int MaxFavoritedMoviesRequest { get; set; }
+        public static int MaxFavoritedShowsRequest { get; set; }
         public static int MaxTrendingMoviesRequest { get; set; }
         public static int MaxTrendingShowsRequest { get; set; }
         public static int MaxPopularMoviesRequest { get; set; }
@@ -226,6 +236,8 @@ namespace TraktPlugin
         public static string UserRefreshToken { get; set; }
         public static int TvCalendarMaxDays { get; set; }
         public static int MovieCalendarMaxDays { get; set; }
+        public static string FavoritedMoviesPeriod { get; set; }
+        public static string FavoritedShowsPeriod { get; set; }
         #endregion
 
         #region Constants
@@ -344,6 +356,14 @@ namespace TraktPlugin
         private const string cRememberLastSelectedActivity = "RememberLastSelectedActivity";
         private const string cMovPicsRatingDlgDelay = "MovPicsRatingDlgDelay";
         private const string cShowRateDlgForPlaylists = "ShowRateDlgForPlaylists";
+        private const string cFavoritedMoviesHideWatched = "FavoritedMoviesHideWatched";
+        private const string cFavoritedMoviesHideWatchlisted = "FavoritedMoviesHideWatchlisted";
+        private const string cFavoritedMoviesHideCollected = "FavoritedMoviesHideCollected";
+        private const string cFavoritedMoviesHideRated = "FavoritedMoviesHideRated";
+        private const string cFavoritedShowsHideWatched = "FavoritedShowsHideWatched";
+        private const string cFavoritedShowsHideWatchlisted = "FavoritedShowsHideWatchlisted";
+        private const string cFavoritedShowsHideCollected = "FavoritedShowsHideCollected";
+        private const string cFavoritedShowsHideRated = "FavoritedShowsHideRated";
         private const string cTrendingMoviesHideWatched = "TrendingMoviesHideWatched";
         private const string cTrendingMoviesHideWatchlisted = "TrendingMoviesHideWatchlisted";
         private const string cTrendingMoviesHideCollected = "TrendingMoviesHideCollected";
@@ -395,6 +415,8 @@ namespace TraktPlugin
         private const string cSyncResumeDelta = "SyncResumeDelta";
         private const string cSyncPlaybackOnEnterPlugin = "SyncPlaybackOnEnterPlugin";
         private const string cSyncPlaybackCacheExpiry = "SyncPlaybackCacheExpiry";
+        private const string cMaxFavoritedMoviesRequest = "MaxFavoritedMoviesRequest";
+        private const string cMaxFavoritedShowsRequest = "MaxFavoritedShowsRequest";
         private const string cMaxTrendingMoviesRequest = "MaxTrendingMoviesRequest";
         private const string cMaxTrendingShowsRequest = "MaxTrendingShowsRequest";
         private const string cMaxPopularMoviesRequest = "MaxPopularMoviesRequest";
@@ -442,6 +464,8 @@ namespace TraktPlugin
         private const string cTraktOnlineSettings = "TraktOnlineSettings";
         private const string cTvCalendarMaxDays = "TvCalendarMaxDays";
         private const string cMovieCalendarMaxDays = "MovieCalendarMaxDays";
+        private const string cFavoritedMoviesPeriod = "FavoritedMoviesPeriod";
+        private const string cFavoritedShowsPeriod = "FavoritedShowsPeriod";
         #endregion
 
         #region Properties
@@ -804,8 +828,8 @@ namespace TraktPlugin
                 SortByRecommendedShows = xmlreader.GetValueAsString(cTrakt, cSortByRecommendedShows, "{\"Field\": 0,\"Direction\": 0}").FromJSON<SortBy>();
                 SortByUserFavoriteMovies = xmlreader.GetValueAsString( cTrakt, cSortByUserFavoriteMovies, "{\"Field\": 10,\"Direction\": 1}" ).FromJSON<SortBy>();
                 SortByUserFavoriteShows = xmlreader.GetValueAsString( cTrakt, cSortByUserFavoriteShows, "{\"Field\": 10,\"Direction\": 1}" ).FromJSON<SortBy>();
-                SortByFavoritedMovies = xmlreader.GetValueAsString( cTrakt, cSortByFavoritedMovies, "{\"Field\": 9,\"Direction\": 1}" ).FromJSON<SortBy>();
-                SortByFavoritedShows = xmlreader.GetValueAsString( cTrakt, cSortByFavoritedShows, "{\"Field\": 9,\"Direction\": 1}" ).FromJSON<SortBy>();
+                SortByFavoritedMovies = xmlreader.GetValueAsString( cTrakt, cSortByFavoritedMovies, "{\"Field\": 11,\"Direction\": 1}" ).FromJSON<SortBy>();
+                SortByFavoritedShows = xmlreader.GetValueAsString( cTrakt, cSortByFavoritedShows, "{\"Field\": 11,\"Direction\": 1}" ).FromJSON<SortBy>();
                 SortByTrendingMovies = xmlreader.GetValueAsString(cTrakt, cSortByTrendingMovies, "{\"Field\": 5,\"Direction\": 1}").FromJSON<SortBy>();
                 SortByTrendingShows = xmlreader.GetValueAsString(cTrakt, cSortByTrendingShows, "{\"Field\": 5,\"Direction\": 1}").FromJSON<SortBy>();
                 SortByPopularMovies = xmlreader.GetValueAsString(cTrakt, cSortByPopularMovies, "{\"Field\": 7,\"Direction\": 1}").FromJSON<SortBy>();
@@ -819,6 +843,14 @@ namespace TraktPlugin
                 RememberLastSelectedActivity = xmlreader.GetValueAsBool(cTrakt, cRememberLastSelectedActivity, true);
                 MovPicsRatingDlgDelay = GetValueAsIntAndValidate(cTrakt, cMovPicsRatingDlgDelay, 500, 250, 1000);
                 ShowRateDlgForPlaylists = xmlreader.GetValueAsBool(cTrakt, cShowRateDlgForPlaylists, false);
+                FavoritedMoviesHideWatched = xmlreader.GetValueAsBool( cTrakt, cFavoritedMoviesHideWatched, false );
+                FavoritedMoviesHideWatchlisted = xmlreader.GetValueAsBool( cTrakt, cFavoritedMoviesHideWatchlisted, false );
+                FavoritedMoviesHideCollected = xmlreader.GetValueAsBool( cTrakt, cFavoritedMoviesHideCollected, false );
+                FavoritedMoviesHideRated = xmlreader.GetValueAsBool( cTrakt, cFavoritedMoviesHideRated, false );
+                FavoritedShowsHideWatched = xmlreader.GetValueAsBool( cTrakt, cFavoritedShowsHideWatched, false );
+                FavoritedShowsHideWatchlisted = xmlreader.GetValueAsBool( cTrakt, cFavoritedShowsHideWatchlisted, false );
+                FavoritedShowsHideCollected = xmlreader.GetValueAsBool( cTrakt, cFavoritedShowsHideCollected, false );
+                FavoritedShowsHideRated = xmlreader.GetValueAsBool( cTrakt, cFavoritedShowsHideRated, false );
                 TrendingMoviesHideWatched = xmlreader.GetValueAsBool(cTrakt, cTrendingMoviesHideWatched, false);
                 TrendingMoviesHideWatchlisted = xmlreader.GetValueAsBool(cTrakt, cTrendingMoviesHideWatchlisted, false);
                 TrendingMoviesHideCollected = xmlreader.GetValueAsBool(cTrakt, cTrendingMoviesHideCollected, false);
@@ -866,20 +898,22 @@ namespace TraktPlugin
                 SyncResumeDelta = GetValueAsIntAndValidate(cTrakt, cSyncResumeDelta, 5, 0, 600);
                 SyncPlaybackOnEnterPlugin = xmlreader.GetValueAsBool(cTrakt, cSyncPlaybackOnEnterPlugin, false);
                 SyncPlaybackCacheExpiry = GetValueAsIntAndValidate(cTrakt, cSyncPlaybackCacheExpiry, 5, 1, 1440);
-                MaxTrendingMoviesRequest = GetValueAsIntAndValidate(cTrakt, cMaxTrendingMoviesRequest, 40, 1, 1000);
-                MaxTrendingShowsRequest = GetValueAsIntAndValidate(cTrakt, cMaxTrendingShowsRequest, 40, 1, 1000);
-                MaxPopularMoviesRequest = GetValueAsIntAndValidate(cTrakt, cMaxPopularMoviesRequest, 40, 1, 1000);
-                MaxPopularShowsRequest = GetValueAsIntAndValidate(cTrakt, cMaxPopularShowsRequest, 40, 1, 1000);
-                MaxAnticipatedMoviesRequest = GetValueAsIntAndValidate(cTrakt, cMaxAnticipatedMoviesRequest, 40, 1, 1000);
-                MaxAnticipatedShowsRequest = GetValueAsIntAndValidate(cTrakt, cMaxAnticipatedShowsRequest, 40, 1, 1000);
+                MaxFavoritedMoviesRequest = GetValueAsIntAndValidate( cTrakt, cMaxFavoritedMoviesRequest, 100, 1, 250 );
+                MaxFavoritedShowsRequest = GetValueAsIntAndValidate( cTrakt, cMaxFavoritedShowsRequest, 100, 1, 250 );
+                MaxTrendingMoviesRequest = GetValueAsIntAndValidate(cTrakt, cMaxTrendingMoviesRequest, 40, 1, 250 );
+                MaxTrendingShowsRequest = GetValueAsIntAndValidate(cTrakt, cMaxTrendingShowsRequest, 40, 1, 250 );
+                MaxPopularMoviesRequest = GetValueAsIntAndValidate(cTrakt, cMaxPopularMoviesRequest, 100, 1, 250 );
+                MaxPopularShowsRequest = GetValueAsIntAndValidate(cTrakt, cMaxPopularShowsRequest, 100, 1, 250 );
+                MaxAnticipatedMoviesRequest = GetValueAsIntAndValidate(cTrakt, cMaxAnticipatedMoviesRequest, 40, 1, 250 );
+                MaxAnticipatedShowsRequest = GetValueAsIntAndValidate(cTrakt, cMaxAnticipatedShowsRequest, 40, 1, 250 );
                 LastListActivities = xmlreader.GetValueAsString(cTrakt, cLastListActivities, "[]").FromJSONArray<TraktCache.ListActivity>();
                 MaxRelatedMoviesRequest = GetValueAsIntAndValidate(cTrakt, cMaxRelatedMoviesRequest, 10, 1, 100);
                 MaxRelatedMoviesUnWatchedRequest = GetValueAsIntAndValidate(cTrakt, cMaxRelatedMoviesUnWatchedRequest, 40, 1, 100);
                 MaxRelatedShowsRequest = GetValueAsIntAndValidate(cTrakt, cMaxRelatedShowsRequest, 10, 1, 100);
-                MaxRelatedShowsUnWatchedRequest = GetValueAsIntAndValidate(cTrakt, cMaxRelatedShowsUnWatchedRequest, 40, 1, 1000);
-                MaxUserWatchedMoviesRequest = GetValueAsIntAndValidate(cTrakt, cMaxUserWatchedMoviesRequest, 40, 1, 1000);
-                MaxUserWatchedEpisodesRequest = GetValueAsIntAndValidate(cTrakt, cMaxUserWatchedEpisodesRequest, 40, 1, 1000);
-                MaxUserCommentsRequest = GetValueAsIntAndValidate(cTrakt, cMaxUserCommentsRequest, 40, 1, 1000);
+                MaxRelatedShowsUnWatchedRequest = GetValueAsIntAndValidate(cTrakt, cMaxRelatedShowsUnWatchedRequest, 40, 1, 250 );
+                MaxUserWatchedMoviesRequest = GetValueAsIntAndValidate(cTrakt, cMaxUserWatchedMoviesRequest, 40, 1, 250 );
+                MaxUserWatchedEpisodesRequest = GetValueAsIntAndValidate(cTrakt, cMaxUserWatchedEpisodesRequest, 40, 1, 250 );
+                MaxUserCommentsRequest = GetValueAsIntAndValidate(cTrakt, cMaxUserCommentsRequest, 40, 1, 250 );
                 DashboardActivityFilter = xmlreader.GetValueAsString(cTrakt, cDashboardActivityFilter, "{}").FromJSON<ActivityFilter>();
                 SkipMoviesWithNoIdsOnSync = xmlreader.GetValueAsBool(cTrakt, cSkipMoviesWithNoIdsOnSync, true);
                 PersonMovieCreditsDefaultLayout = xmlreader.GetValueAsInt(cTrakt, cPersonMovieCreditsDefaultLayout, 0);
@@ -924,6 +958,8 @@ namespace TraktPlugin
                 OnlineSettings = xmlreader.GetValueAsString(cTrakt, cTraktOnlineSettings, "{}").FromJSON<TraktAPI.DataStructures.TraktSettings>();
                 TvCalendarMaxDays = xmlreader.GetValueAsInt(cTrakt, cTvCalendarMaxDays, 7);
                 MovieCalendarMaxDays = xmlreader.GetValueAsInt(cTrakt, cMovieCalendarMaxDays, 7);
+                FavoritedMoviesPeriod = xmlreader.GetValueAsString( cTrakt, cFavoritedMoviesPeriod, "weekly" );
+                FavoritedShowsPeriod = xmlreader.GetValueAsString( cTrakt, cFavoritedShowsPeriod, "weekly" );
             }
 
             // initialise API settings
@@ -1063,6 +1099,14 @@ namespace TraktPlugin
                 xmlwriter.SetValueAsBool(cTrakt, cSortSeasonsAscending, SortSeasonsAscending);
                 xmlwriter.SetValueAsBool(cTrakt, cRememberLastSelectedActivity, RememberLastSelectedActivity);
                 xmlwriter.SetValueAsBool(cTrakt, cShowRateDlgForPlaylists, ShowRateDlgForPlaylists);
+                xmlwriter.SetValueAsBool( cTrakt, cFavoritedMoviesHideWatched, FavoritedMoviesHideWatched );
+                xmlwriter.SetValueAsBool( cTrakt, cFavoritedMoviesHideWatchlisted, FavoritedMoviesHideWatchlisted );
+                xmlwriter.SetValueAsBool( cTrakt, cFavoritedMoviesHideCollected, FavoritedMoviesHideCollected );
+                xmlwriter.SetValueAsBool( cTrakt, cFavoritedMoviesHideRated, FavoritedMoviesHideRated );
+                xmlwriter.SetValueAsBool( cTrakt, cFavoritedShowsHideWatched, FavoritedShowsHideWatched );
+                xmlwriter.SetValueAsBool( cTrakt, cFavoritedShowsHideWatchlisted, FavoritedShowsHideWatchlisted );
+                xmlwriter.SetValueAsBool( cTrakt, cFavoritedShowsHideCollected, FavoritedShowsHideCollected );
+                xmlwriter.SetValueAsBool( cTrakt, cFavoritedShowsHideRated, FavoritedShowsHideRated );
                 xmlwriter.SetValueAsBool(cTrakt, cTrendingMoviesHideWatched, TrendingMoviesHideWatched);
                 xmlwriter.SetValueAsBool(cTrakt, cTrendingMoviesHideWatchlisted, TrendingMoviesHideWatchlisted);
                 xmlwriter.SetValueAsBool(cTrakt, cTrendingMoviesHideCollected, TrendingMoviesHideCollected);
@@ -1111,6 +1155,8 @@ namespace TraktPlugin
                 xmlwriter.SetValue(cTrakt, cSyncResumeDelta, SyncResumeDelta);
                 xmlwriter.SetValueAsBool(cTrakt, cSyncPlaybackOnEnterPlugin, SyncPlaybackOnEnterPlugin);
                 xmlwriter.SetValue(cTrakt, cSyncPlaybackCacheExpiry, SyncPlaybackCacheExpiry);
+                xmlwriter.SetValue( cTrakt, cMaxFavoritedMoviesRequest, MaxFavoritedMoviesRequest );
+                xmlwriter.SetValue( cTrakt, cMaxFavoritedShowsRequest, MaxFavoritedShowsRequest );
                 xmlwriter.SetValue(cTrakt, cMaxTrendingMoviesRequest, MaxTrendingMoviesRequest);
                 xmlwriter.SetValue(cTrakt, cMaxTrendingShowsRequest, MaxTrendingShowsRequest);
                 xmlwriter.SetValue(cTrakt, cMaxPopularMoviesRequest, MaxPopularMoviesRequest);
@@ -1166,6 +1212,8 @@ namespace TraktPlugin
                 xmlwriter.SetValue(cTrakt, cTraktOnlineSettings, OnlineSettings.ToJSON());
                 xmlwriter.SetValue(cTrakt, cTvCalendarMaxDays, TvCalendarMaxDays);
                 xmlwriter.SetValue(cTrakt, cMovieCalendarMaxDays, MovieCalendarMaxDays);
+                xmlwriter.SetValue( cTrakt, cFavoritedMoviesPeriod, FavoritedMoviesPeriod );
+                xmlwriter.SetValue( cTrakt, cFavoritedShowsPeriod, FavoritedShowsPeriod );
             }
 
             Settings.SaveCache();

--- a/TraktPlugin/TraktSettings.cs
+++ b/TraktPlugin/TraktSettings.cs
@@ -41,6 +41,10 @@ namespace TraktPlugin
         public static int LogLevel { get; set; }
         public static int SyncTimerLength { get; set; }
         public static int SyncStartDelay { get; set; }
+        public static int UserFavoriteMoviesDefaultLayout { get; set; }
+        public static int UserFavoriteShowsDefaultLayout { get; set; }
+        public static int FavoritedMoviesDefaultLayout { get; set; }
+        public static int FavoritedShowsDefaultLayout { get; set; }
         public static int TrendingMoviesDefaultLayout { get; set; }
         public static int TrendingShowsDefaultLayout { get; set; }
         public static int PopularMoviesDefaultLayout { get; set; }
@@ -97,6 +101,10 @@ namespace TraktPlugin
         public static bool ShowRecommendationHideWatchlisted { get; set; }
         public static int ShowRecommendationStartYear { get; set; }
         public static int ShowRecommendationEndYear { get; set; }
+        public static SortBy SortByUserFavoriteMovies { get; set; }
+        public static SortBy SortByUserFavoriteShows { get; set; }
+        public static SortBy SortByFavoritedMovies { get; set; }
+        public static SortBy SortByFavoritedShows { get; set; }
         public static SortBy SortByTrendingMovies { get; set; }
         public static SortBy SortByPopularMovies { get; set; }
         public static SortBy SortByRecommendedMovies { get; set; }
@@ -253,6 +261,10 @@ namespace TraktPlugin
         private const string cAlreadyExistMovies = "AlreadyExistMovies";
         private const string cSyncTimerLength = "SyncTimerLength";
         private const string cSyncStartDelay = "SyncStartDelay";
+        private const string cUserFavoriteMoviesDefaultLayout = "UserFavoriteMoviesDefaultLayout";
+        private const string cUserFavoriteShowsDefaultLayout = "UserFavoriteShowsDefaultLayout";
+        private const string cFavoritedMoviesDefaultLayout = "FavoritedMoviesDefaultLayout";
+        private const string cFavoritedShowsDefaultLayout = "FavoritedShowsDefaultLayout";
         private const string cTrendingMoviesDefaultLayout = "TrendingMoviesDefaultLayout";
         private const string cTrendingShowsDefaultLayout = "TrendingShowsDefaultLayout";
         private const string cPopularMoviesDefaultLayout = "PopularMoviesDefaultLayout";
@@ -309,6 +321,10 @@ namespace TraktPlugin
         private const string cShowRecommendationHideWatchlisted = "ShowRecommendationHideWatchlisted";
         private const string cShowRecommendationStartYear = "ShowRecommendationStartYear";
         private const string cShowRecommendationEndYear = "ShowRecommendationEndYear";
+        private const string cSortByUserFavoriteMovies = "SortByUserFavoriteMovies";
+        private const string cSortByUserFavoriteShows = "SortByUserFavoriteShows";
+        private const string cSortByFavoritedMovies = "SortByFavoritedMovies";
+        private const string cSortByFavoritedShows = "SortByFavoritedShows";
         private const string cSortByTrendingMovies = "SortByTrendingMovies";
         private const string cSortByPopularMovies = "SortByPopularMovies";
         private const string cSortByRecommendedMovies = "SortByRecommendedMovies";
@@ -734,6 +750,10 @@ namespace TraktPlugin
                 LogLevel = xmlreader.GetValueAsInt("general", "loglevel", 1);
                 SyncTimerLength = GetValueAsIntAndValidate(cTrakt, cSyncTimerLength, 24, 1, 168);
                 SyncStartDelay = GetValueAsIntAndValidate(cTrakt, cSyncStartDelay, 5000, 0, 300000);
+                UserFavoriteMoviesDefaultLayout = xmlreader.GetValueAsInt( cTrakt, cUserFavoriteMoviesDefaultLayout, 0 );
+                UserFavoriteShowsDefaultLayout = xmlreader.GetValueAsInt( cTrakt, cUserFavoriteShowsDefaultLayout, 0 );
+                FavoritedMoviesDefaultLayout = xmlreader.GetValueAsInt( cTrakt, cFavoritedMoviesDefaultLayout, 0 );
+                FavoritedShowsDefaultLayout = xmlreader.GetValueAsInt( cTrakt, cFavoritedShowsDefaultLayout, 0 );
                 TrendingMoviesDefaultLayout = xmlreader.GetValueAsInt(cTrakt, cTrendingMoviesDefaultLayout, 0);
                 TrendingShowsDefaultLayout = xmlreader.GetValueAsInt(cTrakt, cTrendingShowsDefaultLayout, 0);
                 PopularMoviesDefaultLayout = xmlreader.GetValueAsInt(cTrakt, cPopularMoviesDefaultLayout, 0);
@@ -782,6 +802,10 @@ namespace TraktPlugin
                 ShowRecommendationEndYear = xmlreader.GetValueAsInt(cTrakt, cShowRecommendationEndYear, 0);
                 SortByRecommendedMovies = xmlreader.GetValueAsString(cTrakt, cSortByRecommendedMovies, "{\"Field\": 0,\"Direction\": 0}").FromJSON<SortBy>();
                 SortByRecommendedShows = xmlreader.GetValueAsString(cTrakt, cSortByRecommendedShows, "{\"Field\": 0,\"Direction\": 0}").FromJSON<SortBy>();
+                SortByUserFavoriteMovies = xmlreader.GetValueAsString( cTrakt, cSortByUserFavoriteMovies, "{\"Field\": 9,\"Direction\": 1}" ).FromJSON<SortBy>();
+                SortByUserFavoriteShows = xmlreader.GetValueAsString( cTrakt, cSortByUserFavoriteShows, "{\"Field\": 9,\"Direction\": 1}" ).FromJSON<SortBy>();
+                SortByFavoritedMovies = xmlreader.GetValueAsString( cTrakt, cSortByFavoritedMovies, "{\"Field\": 9,\"Direction\": 1}" ).FromJSON<SortBy>();
+                SortByFavoritedShows = xmlreader.GetValueAsString( cTrakt, cSortByFavoritedShows, "{\"Field\": 9,\"Direction\": 1}" ).FromJSON<SortBy>();
                 SortByTrendingMovies = xmlreader.GetValueAsString(cTrakt, cSortByTrendingMovies, "{\"Field\": 5,\"Direction\": 1}").FromJSON<SortBy>();
                 SortByTrendingShows = xmlreader.GetValueAsString(cTrakt, cSortByTrendingShows, "{\"Field\": 5,\"Direction\": 1}").FromJSON<SortBy>();
                 SortByPopularMovies = xmlreader.GetValueAsString(cTrakt, cSortByPopularMovies, "{\"Field\": 7,\"Direction\": 1}").FromJSON<SortBy>();
@@ -969,6 +993,10 @@ namespace TraktPlugin
                 //TODOxmlwriter.SetValue(cTrakt, cAlreadyExistMovies, AlreadyExistMovies.ToJSON());
                 xmlwriter.SetValue(cTrakt, cSyncTimerLength, SyncTimerLength);
                 xmlwriter.SetValue(cTrakt, cSyncStartDelay, SyncStartDelay);
+                xmlwriter.SetValue(cTrakt, cUserFavoriteMoviesDefaultLayout, UserFavoriteMoviesDefaultLayout);
+                xmlwriter.SetValue(cTrakt, cUserFavoriteShowsDefaultLayout, UserFavoriteShowsDefaultLayout);
+                xmlwriter.SetValue(cTrakt, cFavoritedMoviesDefaultLayout, FavoritedMoviesDefaultLayout);
+                xmlwriter.SetValue(cTrakt, cFavoritedShowsDefaultLayout, FavoritedShowsDefaultLayout);
                 xmlwriter.SetValue(cTrakt, cTrendingMoviesDefaultLayout, TrendingMoviesDefaultLayout);
                 xmlwriter.SetValue(cTrakt, cTrendingShowsDefaultLayout, TrendingShowsDefaultLayout);
                 xmlwriter.SetValue(cTrakt, cPopularMoviesDefaultLayout, PopularMoviesDefaultLayout);
@@ -1017,6 +1045,10 @@ namespace TraktPlugin
                 xmlwriter.SetValue(cTrakt, cShowRecommendationEndYear, ShowRecommendationEndYear);
                 xmlwriter.SetValue(cTrakt, cSortByRecommendedMovies, SortByRecommendedMovies.ToJSON());
                 xmlwriter.SetValue(cTrakt, cSortByRecommendedShows, SortByRecommendedShows.ToJSON());
+                xmlwriter.SetValue(cTrakt, cSortByUserFavoriteMovies, SortByUserFavoriteMovies.ToJSON());
+                xmlwriter.SetValue(cTrakt, cSortByUserFavoriteShows, SortByUserFavoriteShows.ToJSON());
+                xmlwriter.SetValue(cTrakt, cSortByFavoritedMovies, SortByFavoritedMovies.ToJSON());
+                xmlwriter.SetValue(cTrakt, cSortByFavoritedShows, SortByFavoritedShows.ToJSON());
                 xmlwriter.SetValue(cTrakt, cSortByTrendingMovies, SortByTrendingMovies.ToJSON());
                 xmlwriter.SetValue(cTrakt, cSortByTrendingShows, SortByTrendingShows.ToJSON());
                 xmlwriter.SetValue(cTrakt, cSortByPopularMovies, SortByPopularMovies.ToJSON());

--- a/TraktPlugin/TraktSettings.cs
+++ b/TraktPlugin/TraktSettings.cs
@@ -802,8 +802,8 @@ namespace TraktPlugin
                 ShowRecommendationEndYear = xmlreader.GetValueAsInt(cTrakt, cShowRecommendationEndYear, 0);
                 SortByRecommendedMovies = xmlreader.GetValueAsString(cTrakt, cSortByRecommendedMovies, "{\"Field\": 0,\"Direction\": 0}").FromJSON<SortBy>();
                 SortByRecommendedShows = xmlreader.GetValueAsString(cTrakt, cSortByRecommendedShows, "{\"Field\": 0,\"Direction\": 0}").FromJSON<SortBy>();
-                SortByUserFavoriteMovies = xmlreader.GetValueAsString( cTrakt, cSortByUserFavoriteMovies, "{\"Field\": 9,\"Direction\": 1}" ).FromJSON<SortBy>();
-                SortByUserFavoriteShows = xmlreader.GetValueAsString( cTrakt, cSortByUserFavoriteShows, "{\"Field\": 9,\"Direction\": 1}" ).FromJSON<SortBy>();
+                SortByUserFavoriteMovies = xmlreader.GetValueAsString( cTrakt, cSortByUserFavoriteMovies, "{\"Field\": 10,\"Direction\": 1}" ).FromJSON<SortBy>();
+                SortByUserFavoriteShows = xmlreader.GetValueAsString( cTrakt, cSortByUserFavoriteShows, "{\"Field\": 10,\"Direction\": 1}" ).FromJSON<SortBy>();
                 SortByFavoritedMovies = xmlreader.GetValueAsString( cTrakt, cSortByFavoritedMovies, "{\"Field\": 9,\"Direction\": 1}" ).FromJSON<SortBy>();
                 SortByFavoritedShows = xmlreader.GetValueAsString( cTrakt, cSortByFavoritedShows, "{\"Field\": 9,\"Direction\": 1}" ).FromJSON<SortBy>();
                 SortByTrendingMovies = xmlreader.GetValueAsString(cTrakt, cSortByTrendingMovies, "{\"Field\": 5,\"Direction\": 1}").FromJSON<SortBy>();

--- a/TraktPlugin/TraktTranslations.cs
+++ b/TraktPlugin/TraktTranslations.cs
@@ -399,6 +399,7 @@ namespace TraktPlugin.GUI
         public static string CostumeSupervisor = "Costume Supervisor";
         public static string Country = "Country";
         public static string CurrentPage = "Current Page";
+        public static string CurrentPeriod = "Period: {0}";
         public static string CustomLists = "Custom Lists";
         public static string Crew = "Crew";
 
@@ -487,6 +488,8 @@ namespace TraktPlugin.GUI
         public static string FriendRequestMessage = "You have {0} friend requests, approve or deny from friends window";
         public static string FollowerRequestMessage = "You have {0} follower requests, approve or deny from network window";
         public static string FullName = "Full Name";
+        public static string FavoritedMovies = "Favorited Movies";
+        public static string FavoritedShows = "Favorited Shows";
         public static string FavoriteMovies = "Favorite Movies";
         public static string FavoriteShows = "Favorite Shows";
         public static string FavoriteSeasons = "Favorite Seasons";
@@ -557,6 +560,8 @@ namespace TraktPlugin.GUI
         public static string GettingSearchResults = "Getting Search Results";
         public static string GettingTrendingMovies = "Getting Trending Movies";
         public static string GettingTrendingShows = "Getting Trending Shows";
+        public static string GettingFavoritedMovies = "Getting Favorited Movies";
+        public static string GettingFavoritedShows = "Getting Favorited Shows";
         public static string GettingPopularMovies = "Getting Popular Movies";
         public static string GettingPopularShows = "Getting Popular Shows";
         public static string GettingRecommendedMovies = "Getting Recommended Movies";
@@ -696,6 +701,8 @@ namespace TraktPlugin.GUI
         public static string NoFollowerReqTaunt = "You have no follower requests!";
         public static string NoTrendingMovies = "No Movies currently being watched!";
         public static string NoTrendingShows = "No Shows currently being watched!";
+        public static string NoFavoritedMovies = "No Favorited Movies Found!";
+        public static string NoFavoritedShows = "No Favorited Shows Found!";
         public static string NoMovieRecommendations = "No Movie Recommendations Found!";
         public static string NoShowRecommendations = "No Show Recommendations Found!";
         public static string NoMovieWatchList = "{0} has no movies in Watchlist!";
@@ -736,6 +743,11 @@ namespace TraktPlugin.GUI
         public static string People = "People";
         public static string Percentage = "Percentage";
         public static string Protected = "Protected";
+        public static string Period = "Period";
+        public static string PeriodDaily = "Daily";
+        public static string PeriodWeekly = "Weekly";
+        public static string PeriodMonthly = "Monthly";
+        public static string PeriodAll = "All";
         public static string Person = "Person";
         public static string PersonSummary = "Person Summary";
         public static string PersonWatching = "1 Person Watching";
@@ -1044,6 +1056,7 @@ namespace TraktPlugin.GUI
         public static string UserProfile = "User Profile";
         public static string UserRatingsDistribution = "Ratings distribution 1 to 10 hearts";
         public static string UserLoginSuccess = "User {0} successfully authorized to use trakt account";
+        public static string UserCount = "User Count";
 
         // V
         public static string VideoAssistOperator = "Video Assist Operator";

--- a/TraktPlugin/TraktTranslations.cs
+++ b/TraktPlugin/TraktTranslations.cs
@@ -487,6 +487,10 @@ namespace TraktPlugin.GUI
         public static string FriendRequestMessage = "You have {0} friend requests, approve or deny from friends window";
         public static string FollowerRequestMessage = "You have {0} follower requests, approve or deny from network window";
         public static string FullName = "Full Name";
+        public static string FavoriteMovies = "Favorite Movies";
+        public static string FavoriteShows = "Favorite Shows";
+        public static string FavoriteSeasons = "Favorite Seasons";
+        public static string FavoriteEpisodes = "Favorite Episodes";
 
         // G
         public static string Gaffer = "Gaffer";
@@ -536,6 +540,7 @@ namespace TraktPlugin.GUI
         public static string GettingActivity = "Getting Activity";
         public static string GettingCalendar = "Getting Calendar";
         public static string GettingEpisodes = "Getting Episodes";
+        public static string GettingFavorites = "Getting Favorites";
         public static string GettingFriendsList = "Getting Friends List";
         public static string GettingFriendsRequests = "Getting Friends Requests";
         public static string GettingFollowerRequests = "Getting Follower Requests";
@@ -666,10 +671,6 @@ namespace TraktPlugin.GUI
         public static string MusicEditor = "Music Editor";
         public static string MovieCredits = "Movie Credits";
         public static string MovieCount = "{0} Movies";
-        public static string MyFavoriteMovies = "Favorite Movies";
-        public static string MyFavoriteShows = "Favorite Shows";
-        public static string MyFavoriteSeasons = "Favorite Seasons";
-        public static string MyFavoriteEpisodes = "Favorite Episodes  ";
 
         // N
         public static string Name = "Name";
@@ -700,6 +701,8 @@ namespace TraktPlugin.GUI
         public static string NoMovieWatchList = "{0} has no movies in Watchlist!";
         public static string NoShowWatchList = "{0} has no shows in Watchlist!";
         public static string NoEpisodeWatchList = "{0} has no episodes in Watchlist!";
+        public static string NoMovieFavorites = "{0} has no movies in Favorites!";
+        public static string NoShowFavorites = "{0} has no shows in Favorites!";
         public static string NoSearchTypesSelected = "You must first select one or more search types\nbefore performing an online search.";
         public static string NoShoutsForItem = "No Shouts for {0}!";
         public static string NoPeopleToSearch = "There are no people to search by.";


### PR DESCRIPTION
The following new GUI windows are supported:
- Trakt.Favorited.Shows.xml (community-favourited shows by time period: all, daily, weekly and monthly)
- Trakt.Favorited.Movies.xml (community-favourited movies by time period)
- Trakt.UserFavorite.Shows.xml (user favourite shows)
- Trakt.UserFavorite.Movies.xml (user favourite movies)

Titan skin has been updated to support these. In the Titan skin, you can access the community-favourited movies and shows from the TV (`Trakt.TV.Menu.xml`) and Movies (`Trakt.Movies.Menu.xml`) GUI, and you can access the user favourites from the Lists GUI (`Trakt.Lists.Menu.xml`).

See the Titan skin for details on Window IDs and supported controls; for the **most** part, these can use common movie and show properties.